### PR TITLE
IR Remote, raise Exceptions when instantiating a sensor without a gpg

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -2029,7 +2029,7 @@ class Remote(Sensor):
 
         :param str port = "AD1": The port to which we connect the `Infrared Receiver`_.
         :param easygopigo3.EasyGoPiGo3 gpg = None: The :py:class:`~easygopigo3.EasyGoPiGo3` object that we need for instantiating this object.
-        :raises Exception: When the :py:class:`~easygopigo3.Sensor` couldn't be instantiated.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``"AD1"`` and ``"AD2"`` ports' location on the `GoPiGo3`_ robot can be seen in the following graphical representation: :ref:`hardware-ports-section`.
 
@@ -2041,11 +2041,32 @@ class Remote(Sensor):
             raise
 
     def read(self):
+        """
+        Reads the numeric code received by the `Infrared Receiver`_.
+
+        :return: The numeric code of the symbol that was pressed on the `Infrared Remote`_.
+        :rtype: int
+
+        The numeric code represents the index of the :py:attr:`~easygopigo3.Remote.keycodes` list.
+        By accessing the :py:attr:`~easygopigo3.Remote.keycodes` elements with the numeric code, you
+        get the symbol that was pressed on the `Infrared Remote`_.
+
+        For only getting the symbol that was pressed on the `Infrared Remote`_, please check the :py:meth:`~easygopigo3.Remote.get_remote_code` method.
+
+        .. warning::
+
+           On :py:class:`~gopigo3.SensorError` exception:
+
+            * ``"Invalid Reading"`` string is printed in the console.
+            * The value of *-1* is returned.
+
+        """
         try:
             val = self.gpg.get_grove_value(self.get_port_ID())
             return val
         except gopigo3.SensorError as e:
             print("Invalid Reading")
+            return -1
 
 
     def get_remote_code(self):

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -1990,7 +1990,7 @@ class ButtonSensor(DigitalSensor):
 
 class Remote(Sensor):
 
-    keycodes = ["up", "left", "ok", "right","down","1","2","3","4","5","6","7", "8","9","star","0","hash"]
+    keycodes = ["up", "left", "ok", "right","down","1","2","3","4","5","6","7", "8","9","*","0","#"]
     def __init__(self, port="AD1",gpg=None):
         try:
             Sensor.__init__(self, port, "IR", gpg)

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -2062,7 +2062,7 @@ class Remote(Sensor):
            On :py:class:`~gopigo3.SensorError` exception:
 
             * ``"Invalid Reading"`` string is printed in the console.
-            * The value of *-1* is returned.
+            * The value of **-1** is returned.
 
         """
         try:

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -36,7 +36,7 @@ import os
 try:
     from line_follower import line_sensor
     from line_follower import scratch_line
-    
+
     # is_line_follower_accessible not really used, just in case
     is_line_follower_accessible = True
 except:
@@ -873,6 +873,7 @@ class Sensor(object):
         :param str port: Specifies the port with which we want to communicate / interact with. The string literals we can use for identifying a port are found in the following graphical drawing : :ref:`hardware-ports-section`.
         :param str pinmode: The mode of operation of the pin we're selecting.
         :param easygopigo3.EasyGoPiGo3 gpg: An instantiated object of the :py:class:`~easygopigo3.EasyGoPiGo3` class. We need this :py:class:`~easygopigo3.EasyGoPiGo3` class for setting up the `GoPiGo3`_ robot's pins.
+        :raises TypeError: If the `gpg` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following string values:
 
@@ -900,9 +901,9 @@ class Sensor(object):
 
         """
         debug("Sensor init")
-        
-        if gpg is None:
-            raise IOError("When instantiating a sensor, a valid GoPiGo parameter is required ")
+
+        if type(gpg) != EasyGoPiGo3:
+            raise TypeError("Use an EasyGoPiGo3 object for the gpg parameter.")
         self.gpg = gpg
         debug(pinmode)
         self.set_port(port)
@@ -1466,7 +1467,7 @@ class UltraSonicSensor(AnalogSensor):
             self.set_pin(1)
             self.set_descriptor("Ultrasonic sensor")
 
-        except: 
+        except:
             raise
 
 
@@ -1855,8 +1856,8 @@ class Led(AnalogSensor):
             self.set_pin(1)
             self.set_descriptor("LED")
         except:
-            raise 
-            
+            raise
+
     def light_on(self, power):
         """
         Sets the duty cycle for the `Grove LED`_.
@@ -1997,7 +1998,7 @@ class Remote(Sensor):
             self.set_descriptor("Remote Control")
         except:
             raise
-    
+
     def read(self):
         try:
             val = self.gpg.get_grove_value(self.get_port_ID())
@@ -2017,7 +2018,7 @@ class Remote(Sensor):
         key = self.read()
         if key > 0 and key < len(self.keycodes)+1:
             return self.keycodes[self.read()-1]
-        
+
         return ""
 ##########################
 
@@ -2064,7 +2065,7 @@ class LineFollower(Sensor):
         """
         if is_line_follower_accessible is False:
             raise ImportError("Line Follower library not found")
-            
+
         try:
             Sensor.__init__(self, port, "INPUT", gpg)
             self.set_descriptor("Line Follower")
@@ -2294,11 +2295,11 @@ try:
 except:
     try:
         from mock_package import distance_sensor
-        print ("Loading library without distance sensor")    
+        print ("Loading library without distance sensor")
     except:
         pass
 
-      
+
 class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
     """
     Class for the `Distance Sensor`_ device.
@@ -2334,7 +2335,7 @@ class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
             Sensor.__init__(self, port, "OUTPUT", gpg)
         except:
             raise
-            
+
         try:
             distance_sensor.DistanceSensor.__init__(self)
         except Exception as e:
@@ -2358,10 +2359,10 @@ class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
 
         """
 
-        # 8190 is what the sensor sends when it's out of range     
-        # we're just setting a default value      
-        mm = 8190     
-        readings = []     
+        # 8190 is what the sensor sends when it's out of range
+        # we're just setting a default value
+        mm = 8190
+        readings = []
         attempt = 0
 
         # try 3 times to have a reading that is

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -2071,19 +2071,22 @@ class Remote(Sensor):
 
     def get_remote_code(self):
         """
-        """
-        '''
-        Returns the keycode from the remote control
-        No preprocessing
-        You have to check that length > 0
-            before handling the code value
-        if the IR Receiver is not enabled, this will return -1
-        '''
-        key = self.read()
-        if key > 0 and key < len(self.keycodes)+1:
-            return self.keycodes[self.read()-1]
+        Returns the symbol of the pressed key in a string format.
 
-        return ""
+        :return: The symbol that was pressed on the `Infrared Remote`_.
+        :rtype: str
+
+        Check the :py:attr:`~easygopigo3.Remote.keycodes` list for seeing what strings this method can return.
+        On error or when nothing is read, an empty string is returned.
+
+        """
+        string = ""
+        key = self.read()
+
+        if key > 0 and key < len(self.keycodes)+1:
+            string = self.keycodes[self.read()-1]
+
+        return string
 ##########################
 
 

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -1178,6 +1178,7 @@ class AnalogSensor(Sensor):
         :param str port: The port to which the sensor/actuator is connected.
         :param str pinmode: The pin mode of the device that's connected to the `GoPiGo3`_.
         :param easygopigo3.EasyGoPiGo3 gpg: Required object for instantiating an :py:class:`~easygopigo3.AnalogSensor` object.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The available ``port``'s for use are the following:
 
@@ -1326,6 +1327,7 @@ class LightSensor(AnalogSensor):
 
         :param str port = "AD1": Port to which we have the `Grove Light Sensor`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.LightSensor` object.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -1391,6 +1393,7 @@ class SoundSensor(AnalogSensor):
 
         :param str port = "AD1": Port to which we have the `Grove Sound Sensor`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.SoundSensor` object.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -1459,7 +1462,7 @@ class UltraSonicSensor(AnalogSensor):
 
         :param str port = "AD1": Port to which we have the `Grove Ultrasonic Sensor`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.UltraSonicSensor` object.
-        :raises IOError: If there is a communication error with the `GoPiGo3`_ robot.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -1710,9 +1713,9 @@ class Buzzer(AnalogSensor):
 
         :param str port = "AD1": Port to which we have the `Grove Buzzer`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.Buzzer` object.
-        :raises AtrributeError: If an attribute couldn't be found - you shouldn't worry about this one.
         :var int power = 50: Duty cycle of the signal that's put on the buzzer.
         :var int freq = 329: Frequency of the signal that's put on the buzzer. 329Hz is synonymous to E4 musical note. See :py:attr:`~.easygopigo3.Buzzer.scale` for more musical notes.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -1850,7 +1853,7 @@ class Led(AnalogSensor):
 
         :param str port = "AD1": Port to which we have the `Grove LED`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.Led` object.
-        :raises ValueError: If an inappropriate value was tried to be assigned - you shouldn't worry about this one.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -1970,6 +1973,7 @@ class ButtonSensor(DigitalSensor):
 
         :param str port = "AD1": Port to which we have the `Grove Button`_ connected to.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object used for instantiating a :py:class:`~easygopigo3.Button` object.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following values:
 
@@ -2123,7 +2127,9 @@ class LineFollower(Sensor):
 
         :param str port = "I2C": The port to which we have connected the `Line Follower`_ sensor.
         :param easygopigo3.EasyGoPiGo3 gpg = None: The :py:class:`~easygopigo3.EasyGoPiGo3` object that we need for instantiating this object.
-        :raises ValueError: If the ``line_sensor`` library couldn't be found.
+        :raises ImportError: If the :py:mod:`line_follower` module couldn't be found.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
+
 
         The only value the ``port`` parameter can take is ``"I2C"``.
 
@@ -2288,6 +2294,7 @@ class Servo(Sensor):
 
         :param str port = "SERVO1": The port to which we have connected the `servo`_.
         :param easygopigo3.EasyGoPiGo3 gpg = None: :py:class:`~easygopigo3.EasyGoPiGo3` object that we need for instantiation.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The available ports that can be used for a `servo`_ are:
 
@@ -2394,6 +2401,8 @@ class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
 
         :param str port = "I2C": Port to which the distance sensor is connected.
         :param easygopigo3.EasyGoPiGo3 gpg = None: Object that's required for instantianting a :py:class:`~easygopigo3.DistanceSensor` object.
+        :raises IOError: If :py:class:`di_sensors.distance_sensor.DistanceSensor` can't be found. Probably the :py:mod:`di_sensors` module isn't installed.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         To see where the ports are located on the `GoPiGo3`_ robot, please take a look at the following diagram: :ref:`hardware-ports-section`.
 

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -785,7 +785,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         | Initialises a :py:class:`~easygopigo3.DistanceSensor` object and then returns it.
 
-        :param Str port: the only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
+        :param str port: the only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
         :returns: An instance of the :py:class:`~easygopigo3.DistanceSensor` class and with the port set to ``port``'s value.
 
         The ``"I2C"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -813,7 +813,16 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         return DHTSensor(port, self, sensor_type)
 
-    def init_remote(self,port="AD1"):
+    def init_remote(self, port="AD1"):
+        """
+        | Initialises a :py:class:`~easygopigo3.Remote` object and then returns it.
+
+        :param str port: Can be set to either ``"AD1"`` or ``"AD2"``. Set by default to ``"AD1"``.
+        :returns: An instance of the :py:class:`~easygopigo3.Remote` class and with the port set to ``port``'s value.
+
+        The ``"AD1"`` port is mapped to the following :ref:`hardware-ports-section`.
+
+        """
         return Remote(port,self)
 
 # the following functions may be redundant
@@ -873,7 +882,7 @@ class Sensor(object):
         :param str port: Specifies the port with which we want to communicate / interact with. The string literals we can use for identifying a port are found in the following graphical drawing : :ref:`hardware-ports-section`.
         :param str pinmode: The mode of operation of the pin we're selecting.
         :param easygopigo3.EasyGoPiGo3 gpg: An instantiated object of the :py:class:`~easygopigo3.EasyGoPiGo3` class. We need this :py:class:`~easygopigo3.EasyGoPiGo3` class for setting up the `GoPiGo3`_ robot's pins.
-        :raises TypeError: If the `gpg` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
+        :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
 
         The ``port`` parameter can take the following string values:
 
@@ -1990,9 +1999,41 @@ class ButtonSensor(DigitalSensor):
 
 
 class Remote(Sensor):
+    """
+    Class for interfacing with the `Infrared Receiver`_.
 
+    With this sensor, you can command your `GoPiGo3`_ with an `Infrared Remote`_.
+
+    In order to create an object of this class, we would do it like in the following example.
+
+    .. code-block:: python
+
+        # initialize an EasyGoPiGo3 object
+        gpg3_obj = EasyGoPiGo3()
+
+        # now initialize a Remote object
+        remote_control = gpg3_obj.init_remote()
+
+        # read whatever command you want from the remote by using
+        # the [remote_control] object
+
+    """
+
+    #: List for mapping the codes we get with the :py:meth:`~easygopigo3.Remote.read` method to
+    #: the actual symbols we see on the `Infrared Remote`_.
     keycodes = ["up", "left", "ok", "right","down","1","2","3","4","5","6","7", "8","9","*","0","#"]
+
     def __init__(self, port="AD1",gpg=None):
+        """
+        Constructor for initializing a :py:class:`~easygopigo3.Remote` object.
+
+        :param str port = "AD1": The port to which we connect the `Infrared Receiver`_.
+        :param easygopigo3.EasyGoPiGo3 gpg = None: The :py:class:`~easygopigo3.EasyGoPiGo3` object that we need for instantiating this object.
+        :raises Exception: When the :py:class:`~easygopigo3.Sensor` couldn't be instantiated.
+
+        The ``"AD1"`` and ``"AD2"`` ports' location on the `GoPiGo3`_ robot can be seen in the following graphical representation: :ref:`hardware-ports-section`.
+
+        """
         try:
             Sensor.__init__(self, port, "IR", gpg)
             self.set_descriptor("Remote Control")
@@ -2008,6 +2049,8 @@ class Remote(Sensor):
 
 
     def get_remote_code(self):
+        """
+        """
         '''
         Returns the keycode from the remote control
         No preprocessing

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -680,7 +680,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.LightSensor` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.LightSensor` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -692,7 +692,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.SoundSensor` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.SoundSensor` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -704,7 +704,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.UltraSonicSensor` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.UltraSonicSensor` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -716,7 +716,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.Buzzer` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.Buzzer` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -728,7 +728,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.Led` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.Led` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -740,7 +740,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.ButtonSensor` object and then returns it.
 
-        :param str port: Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
+        :param str port = "AD1": Can be either ``"AD1"`` or ``"AD2"``. By default it's set to be ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.ButtonSensor` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` and ``"AD2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -752,7 +752,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.LineFollower` object and then returns it.
 
-        :param str port: The only option for this parameter is ``"I2C"``. The default value for this parameter is already set to ``"I2C"``.
+        :param str port = "I2C": The only option for this parameter is ``"I2C"``. The default value for this parameter is already set to ``"I2C"``.
         :returns: An instance of the :py:class:`~easygopigo3.LineFollower` class and with the port set to ``port``'s value.
 
         The ``"I2C"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -772,7 +772,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.Servo` object and then returns it.
 
-        :param str port: Can be either ``"SERVO1"`` or ``"SERVO2"``. By default it's set to be ``"SERVO1"``.
+        :param str port = "SERVO1": Can be either ``"SERVO1"`` or ``"SERVO2"``. By default it's set to be ``"SERVO1"``.
         :returns: An instance of the :py:class:`~easygopigo3.Servo` class and with the port set to ``port``'s value.
 
         The ``"SERVO1"`` and ``"SERVO2"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -785,7 +785,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         | Initialises a :py:class:`~easygopigo3.DistanceSensor` object and then returns it.
 
-        :param str port: the only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
+        :param str port = "I2C": the only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
         :returns: An instance of the :py:class:`~easygopigo3.DistanceSensor` class and with the port set to ``port``'s value.
 
         The ``"I2C"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -805,7 +805,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.DHTSensor` object and then returns it.
 
-        :param str port: The only available port name is ``"SERIAL"``. The default value is also ``"SERIAL"``, so it can be left alone.
+        :param str port = "SERIAL": The only available port name is ``"SERIAL"``. The default value is also ``"SERIAL"``, so it can be left alone.
         :returns: An instance of the :py:class:`~easygopigo3.DHTSensor` class and with the port set to ``port``'s value.
 
         The ``"SERIAL"`` port is mapped to the following :ref:`hardware-ports-section`.
@@ -817,7 +817,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | Initialises a :py:class:`~easygopigo3.Remote` object and then returns it.
 
-        :param str port: Can be set to either ``"AD1"`` or ``"AD2"``. Set by default to ``"AD1"``.
+        :param str port = "AD1": Can be set to either ``"AD1"`` or ``"AD2"``. Set by default to ``"AD1"``.
         :returns: An instance of the :py:class:`~easygopigo3.Remote` class and with the port set to ``port``'s value.
 
         The ``"AD1"`` port is mapped to the following :ref:`hardware-ports-section`.

--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -15,8 +15,9 @@ except IOError:
 	print(str(IOError))
 	print("make sure you have [package_description.rst] file in the same directory as [setup.py]")
 
-import setuptools
-setuptools.setup(
+from setuptools import setup, find_packages
+
+setup(
     name = "gopigo3",
     version = "1.0.2",
 
@@ -42,7 +43,7 @@ setuptools.setup(
 
     keywords = ['robot', 'gopigo', 'gopigo3', 'dexter industries', 'learning', 'education'],
 
-    packages = ['Examples', 'Examples.Control_Panel', 'Examples.Line_Sensor'],
+    packages=find_packages(),
     py_modules = ['gopigo3','easygopigo3','I2C_mutex'],
     install_requires = ['spidev']
 )

--- a/docs/source/api-advanced.rst
+++ b/docs/source/api-advanced.rst
@@ -53,7 +53,7 @@ AnalogSensor
 .. _gopigo3: https://www.dexterindustries.com/shop/gopigo-advanced-starter-kit/
 .. _gopigo3 package: https://pypi.python.org/pypi/gopigo3
 .. _shop: https://www.dexterindustries.com/shop/
-.. _infrared receiver: https://www.seeedstudio.com/Grove-Infrared-Receiver-p-994.html
+.. _infrared receiver: https://www.dexterindustries.com/shop/grove-infrared-sensor/
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories

--- a/docs/source/api-basic.rst
+++ b/docs/source/api-basic.rst
@@ -157,11 +157,19 @@ DHTSensor
 
    Coming soon!
 
+=====================================
+Remote
+=====================================
+
+.. autoclass:: easygopigo3.Remote
+   :members:
+   :special-members:
+
 
 .. _distance sensor: https://www.dexterindustries.com/shop/distance-sensor/
 .. _gopigo3: https://www.dexterindustries.com/shop/gopigo-advanced-starter-kit/
 .. _shop: https://www.dexterindustries.com/shop/
-.. _infrared receiver: https://www.seeedstudio.com/Grove-Infrared-Receiver-p-994.html
+.. _infrared receiver: https://www.dexterindustries.com/shop/grove-infrared-sensor/
 .. _technical specs: https://www.dexterindustries.com/GoPiGo/learning/hardware-port-description/
 .. _grove light sensor: https://www.dexterindustries.com/shop/grove-light-sensor/
 .. _grove sound sensor: https://www.dexterindustries.com/shop/grove-sound-sensor/
@@ -171,6 +179,7 @@ DHTSensor
 .. _grove button: https://www.dexterindustries.com/shop/grove-button/
 .. _servo: https://www.dexterindustries.com/shop/servo-package/
 .. _line follower: https://www.dexterindustries.com/shop/line-follower-for-gopigo/
+.. _infrared remote: https://www.dexterindustries.com/shop/infrared-remote/
 .. _gopigo3 package: https://pypi.python.org/pypi/gopigo3
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -36,7 +36,6 @@ For programming your `GoPiGo3`_ to do anything you want, read the instructions f
 .. _programming your robot: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/
 .. _shop: https://www.dexterindustries.com/shop/
 .. _distance sensor: https://www.dexterindustries.com/shop/distance-sensor/
-.. _infrared receiver: https://www.seeedstudio.com/Grove-Infrared-Receiver-p-994.html
 .. _technical specs: https://www.dexterindustries.com/GoPiGo/learning/hardware-port-description/
 .. _grove light sensor: https://www.dexterindustries.com/shop/grove-light-sensor/
 .. _grove sound sensor: https://www.dexterindustries.com/shop/grove-sound-sensor/
@@ -46,6 +45,8 @@ For programming your `GoPiGo3`_ to do anything you want, read the instructions f
 .. _grove button: https://www.dexterindustries.com/shop/grove-button/
 .. _servo: https://www.dexterindustries.com/shop/servo-package/
 .. _line follower: https://www.dexterindustries.com/shop/line-follower-for-gopigo/
+.. _infrared receiver: https://www.dexterindustries.com/shop/grove-infrared-sensor/
+.. _infrared remote: https://www.dexterindustries.com/shop/infrared-remote/
 .. _gopigo3 package: https://pypi.python.org/pypi/gopigo3
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/


### PR DESCRIPTION
Easygopigo3 can now be loaded up without the distance sensor, and from anywhere
IR Remote is now in easygopigo but in need of documentation. 
When user instantiates a sensor/actuator and doesn't pass a gpg value, an exception is now raise at instantiating time instead of crashing later on without a good error message.

too many commits are showing, only 2 files are changed 