### PR TITLE
reset_speed() method

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -113,7 +113,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         :var int speed = 300: The speed of the motors should go between **0-1000** DPS.
         :var tuple(int,int,int) left_eye_color = (0,255,255): Set Dex's left eye color to **turqoise**.
         :var tuple(int,int,int) right_eye_color = (0,255,255): Set Dex's right eye color to **turqoise**.
-        :var int DEFAULT_SPEED = 300: starting speed value. Not too fast, not too slow
+        :var int DEFAULT_SPEED = 300: Starting speed value: not too fast, not too slow.
         :raises IOError: When the GoPiGo3 is not detected. It also debugs a message in the terminal.
         :raises gopigo3.FirmwareVersionError: If the GoPiGo3 firmware needs to be updated. It also debugs a message in the terminal.
         :raises Exception: For any other kind of exceptions.

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -113,7 +113,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         :var int speed = 300: The speed of the motors should go between **0-1000** DPS.
         :var tuple(int,int,int) left_eye_color = (0,255,255): Set Dex's left eye color to **turqoise**.
         :var tuple(int,int,int) right_eye_color = (0,255,255): Set Dex's right eye color to **turqoise**.
-        :var in _default_speed = 300: starting speed value. Not too fast, not too slow
+        :var int DEFAULT_SPEED = 300: starting speed value. Not too fast, not too slow
         :raises IOError: When the GoPiGo3 is not detected. It also debugs a message in the terminal.
         :raises gopigo3.FirmwareVersionError: If the GoPiGo3 firmware needs to be updated. It also debugs a message in the terminal.
         :raises Exception: For any other kind of exceptions.
@@ -132,8 +132,8 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         self.sensor_1 = None
         self.sensor_2 = None
-        self._default_speed=300
-        self.set_speed(self._default_speed)
+        self.DEFAULT_SPEED=300
+        self.set_speed(self.DEFAULT_SPEED)
         self.left_eye_color = (0, 255, 255)
         self.right_eye_color = (0, 255, 255)
 
@@ -166,7 +166,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         try:
             self.speed = int(in_speed)
         except:
-            self.speed = self._default_speed
+            self.speed = self.DEFAULT_SPEED
         self.set_motor_limits(self.MOTOR_LEFT + self.MOTOR_RIGHT,
                               dps=self.speed)
 
@@ -184,7 +184,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         | This method resets the speed to its original value
         """
-        self.set_speed(self._default_speed)
+        self.set_speed(self.DEFAULT_SPEED)
 
     def stop(self):
         """

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -182,7 +182,8 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         
     def reset_speed(self):
         """
-        | This method resets the speed to its original value
+        | This method resets the speed to its original value.
+
         """
         self.set_speed(self.DEFAULT_SPEED)
 

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -113,6 +113,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         :var int speed = 300: The speed of the motors should go between **0-1000** DPS.
         :var tuple(int,int,int) left_eye_color = (0,255,255): Set Dex's left eye color to **turqoise**.
         :var tuple(int,int,int) right_eye_color = (0,255,255): Set Dex's right eye color to **turqoise**.
+        :var in _default_speed = 300: starting speed value. Not too fast, not too slow
         :raises IOError: When the GoPiGo3 is not detected. It also debugs a message in the terminal.
         :raises gopigo3.FirmwareVersionError: If the GoPiGo3 firmware needs to be updated. It also debugs a message in the terminal.
         :raises Exception: For any other kind of exceptions.
@@ -131,7 +132,8 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         self.sensor_1 = None
         self.sensor_2 = None
-        self.set_speed(300)
+        self._default_speed=300
+        self.set_speed(self._default_speed)
         self.left_eye_color = (0, 255, 255)
         self.right_eye_color = (0, 255, 255)
 
@@ -155,7 +157,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         .. warning::
 
-             **0-1000** DPS are the *preffered* speeds for the `GoPiGo3`_ robot.
+             **0-1000** DPS are the *preferred* speeds for the `GoPiGo3`_ robot.
              The speed variable can be basically set to any positive value, but factors like *voltage*, *load*, *battery amp rating*, etc, will determine the effective speed of the motors.
 
              Experiments should be run by every user, as each case is unique.
@@ -164,7 +166,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         try:
             self.speed = int(in_speed)
         except:
-            self.speed = 300
+            self.speed = self._default_speed
         self.set_motor_limits(self.MOTOR_LEFT + self.MOTOR_RIGHT,
                               dps=self.speed)
 
@@ -177,6 +179,12 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         """
         return int(self.speed)
+        
+    def reset_speed(self):
+        """
+        | This method resets the speed to its original value
+        """
+        self.set_speed(self._default_speed)
 
     def stop(self):
         """


### PR DESCRIPTION
Introduce a DEFAULT_SPEED variable set to 300 when __init__ is called.
reset_speed sets the speed without having to use a value. Easier to use as complexity is hidden from the user.