### PR TITLE
pip package can't get installed

### DIFF
--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "gopigo3",
-    version = "1.1.0",
+    version = "1.1.1",
 
     description = "Drivers and Examples for using the GoPiGo3 in Python",
     long_description = description,

--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -12,8 +12,7 @@ try:
 		description = file_description.read()
 
 except IOError:
-	print(str(IOError))
-	print("make sure you have [package_description.rst] file in the same directory as [setup.py]")
+	description = "Check more on https://pypi.python.org/pypi/gopigo3"
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
As reported on this forum post:
https://forum.dexterindustries.com/t/python-lib-install-broken/3683

Even though this forum post refers to the `GrovePi` repo, it's the same issue as with the `GoPiGo3`.

After this gets approved, we need to push the changes to `PyPi`.