### PR TITLE
spi-dev is not meant to be installed via the /etc/modules

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -71,13 +71,15 @@ echo ""
 sudo bash $REPO_PATH/Firmware/openocd/install_openocd_compiled.sh
 
 # Adding in /etc/modules
-echo ""
-if grep -q "spi-dev" /etc/modules; then
-    echo "spi-dev already present in /etc/modules"
-else
-    echo spi-dev >> /etc/modules
-    echo "spi-dev added to /etc/modules"
-fi
+# this is not needed with Jessie and leads to a FAILED error at boot
+# (boot does work though)
+# echo ""
+# if grep -q "spi-dev" /etc/modules; then
+#     echo "spi-dev already present in /etc/modules"
+# else
+#     echo spi-dev >> /etc/modules
+#     echo "spi-dev added to /etc/modules"
+# fi
 
 # Enable SPI
 echo ""


### PR DESCRIPTION
This references this forum thread: https://forum.dexterindustries.com/t/failed-to-start-load-kernel-modules-and-no-wifi-interface-found/3587/20

