### PR TITLE
feature - [di-sensors] inclusion of documentation into the GPG3's + some touch-ups

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "DI_Sensors"]
+	path = DI_Sensors
+	url = https://github.com/DexterInd/DI_Sensors

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "DI_Sensors"]
-	path = DI_Sensors
-	url = https://github.com/DexterInd/DI_Sensors

--- a/docs/source/api-advanced.rst
+++ b/docs/source/api-advanced.rst
@@ -1,8 +1,8 @@
 .. _api-advanced-chapter:
 
-##############################
-API Reference Point - Advanced
-##############################
+######################
+API GoPiGo3 - Advanced
+######################
 
 ============
 Requirements
@@ -19,7 +19,7 @@ If you have issues importing these 2 modules, then make sure that:
 
    * You've followed the steps found in :ref:`Getting Started <getting-started-chapter>` guide.
    * You have installed either `Raspbian For Robots`_, the GoPiGo3 `repository`_ or the `GoPiGo3 package`_ (the pip package).
-   * You have the ``gopigo3`` package installed by typing the command ``pip freeze | grep gopigo3`` on your Raspberry Pi's terminal. If the package is installed, then a string with the ``GoPiGo3==[x.y.z]`` format will show up.
+   * You have the ``gopigo3`` package installed by typing the command ``pip freeze | grep gopigo3`` on your Raspberry Pi's terminal. If the package is installed, then a string with the ``gopigo3==[x.y.z]`` format will show up.
 
 If you encounter issues that aren't covered by our :ref:`Getting Started <getting-started-chapter>` guide or :ref:`FAQ <faq-chapter>` chapter, please head over to our `forum`_.
 

--- a/docs/source/api-basic.rst
+++ b/docs/source/api-basic.rst
@@ -1,8 +1,8 @@
 .. _api-basic-chapter:
 
-###########################
-API Reference Point - Basic
-###########################
+###################
+API GoPiGo3 - Basic
+###################
 
 ============
 Requirements
@@ -19,7 +19,7 @@ If you have issues importing these two modules, then make sure:
 
    * You have followed the steps found in :ref:`Getting Started <getting-started-chapter>` guide.
    * You have installed either `Raspbian For Robots`_, the GoPiGo3 `repository`_ or the `GoPiGo3 package`_ (the pip package).
-   * You have the ``gopigo3`` package installed by typing the command ``pip freeze | grep gopigo3`` on your Raspberry Pi's terminal. If the package is installed, then a string with the ``GoPiGo3==[x.y.z]`` format will show up.
+   * You have the ``gopigo3`` package installed by typing the command ``pip freeze | grep gopigo3`` on your Raspberry Pi's terminal. If the package is installed, then a string with the ``gopigo3==[x.y.z]`` format will show up.
 
 If you encounter issues that aren't covered by our :ref:`Getting Started <getting-started-chapter>` guide or :ref:`FAQ <faq-chapter>` chapter, please head over to our `forum`_.
 
@@ -180,13 +180,6 @@ Remote
 .. autoclass:: easygopigo3.Remote
    :members:
    :special-members:
-
-=====================================
-DI Sensors
-=====================================
-
-.. autoclass:: di_sensors.BNO055.BNO055
-   :members:
 
 
 .. _distance sensor: https://www.dexterindustries.com/shop/distance-sensor/

--- a/docs/source/api-basic.rst
+++ b/docs/source/api-basic.rst
@@ -207,4 +207,4 @@ Remote
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories
-.. _DI-Sensors: http://di-sensors.readthedocs.io/en/master/
+.. _DI-Sensors: http://di-sensors.readthedocs.io

--- a/docs/source/api-basic.rst
+++ b/docs/source/api-basic.rst
@@ -181,6 +181,13 @@ Remote
    :members:
    :special-members:
 
+=====================================
+DI Sensors
+=====================================
+
+.. autoclass:: di_sensors.BNO055.BNO055
+   :members:
+
 
 .. _distance sensor: https://www.dexterindustries.com/shop/distance-sensor/
 .. _gopigo3: https://www.dexterindustries.com/shop/gopigo-advanced-starter-kit/

--- a/docs/source/api-basic.rst
+++ b/docs/source/api-basic.rst
@@ -161,6 +161,11 @@ Servo
 DistanceSensor
 =====================================
 
+.. important::
+
+   The :py:class:`easygopigo3.DistanceSensor` class requires the ``DI_Sensors`` package installed.
+   Please check the documentation of the `DI-Sensors`_'s package on how to install it.
+
 .. autoclass:: easygopigo3.DistanceSensor
    :members:
    :special-members:
@@ -202,3 +207,4 @@ Remote
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories
+.. _DI-Sensors: http://di-sensors.readthedocs.io/en/master/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ from mock import Mock as MagicMock
 import mox
 '''
 sys.path.insert(0, os.path.abspath('../../Software/Python'))
+sys.path.insert(0, os.path.abspath('../../DI_Sensors/Python'))
 '''
 class Mock(MagicMock):
     @classmethod

--- a/docs/source/devguide.rst
+++ b/docs/source/devguide.rst
@@ -22,10 +22,10 @@ Developer's Guide
 Our collaborators
 *****************
 
-The order of our collaborators is not relevant to the their level of implication:
+The following collaborators are ordered alphabetically:
 
-   * Matt Richardson - `Github Account <https://github.com/mattallen37/>`__
-   * Nicole Parrot - `Github Account <https://github.com/cleoqc/>`__
-   * Robert Lucian Chiriac - `Github Account <https://github.com/RobertLucian/>`__
-   * John Cole - `Github Account <https://github.com/johnisanerd/>`__
-   * Shoban Narayan - `Github Account <https://github.com/shoban94>`__
+   * John Cole - `Github Account <https://github.com/johnisanerd/>`__.
+   * Matt Richardson - `Github Account <https://github.com/mattallen37/>`__.
+   * Nicole Parrot - `Github Account <https://github.com/cleoqc/>`__.
+   * Robert Lucian Chiriac - `Github Account <https://github.com/RobertLucian/>`__.
+   * Shoban Narayan - `Github account <https://github.com/shoban94>`__.

--- a/docs/source/devguide.rst
+++ b/docs/source/devguide.rst
@@ -4,9 +4,6 @@
 Developer's Guide
 #################
 
-.. note::
-
-   Coming soon!
 
 ..
   ************************
@@ -21,11 +18,14 @@ Developer's Guide
   Custom libraries
   ****************************************
 
-****************
-Our contributors
-****************
+*****************
+Our collaborators
+*****************
 
-   1. Matt Richardson - `Github Account <https://github.com/mattallen37/>`__
-   2. Nicole Parrot - `Github Account <https://github.com/cleoqc/>`__
-   3. Robert Lucian Chiriac - `Github Account <https://github.com/RobertLucian/>`__
-   4. John Cole - `Github Account <https://github.com/johnisanerd/>`__
+The order of our collaborators is not relevant to the their level of implication:
+
+   * Matt Richardson - `Github Account <https://github.com/mattallen37/>`__
+   * Nicole Parrot - `Github Account <https://github.com/cleoqc/>`__
+   * Robert Lucian Chiriac - `Github Account <https://github.com/RobertLucian/>`__
+   * John Cole - `Github Account <https://github.com/johnisanerd/>`__
+   * Shoban Narayan - `Github Account <https://github.com/shoban94>`__

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,11 +4,6 @@
 Frequently Asked Questions
 ##########################
 
-.. note::
-
-   Coming soon!
-
 For more questions, please head over to our Dexter Industries `forum`_.
-
 
 .. _forum: http://forum.dexterindustries.com/categories

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -47,11 +47,11 @@ You can get it installed/updated by typing the following command:
 
    sudo curl -kL dexterindustries.com/update_sensors | bash
 
-***********************
-Connecting More Sensors
-***********************
+********************
+Connect More Sensors
+********************
 
-The `GoPiGo3`_ can also be paired with our in-house made sensors.
+The `GoPiGo3`_ can also be paired with our in-house sensors.
 At the moment, we've got 4 sensors (one of which is already implemented in the GoPiGo3's package):
 
    * The DI `IMU Sensor`_.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -84,7 +84,7 @@ For more on getting started with these sensors, please check the `DI-Sensors`_ d
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories
-.. _DI-Sensors: http://di-sensors.readthedocs.io/en/master/
+.. _DI-Sensors: http://di-sensors.readthedocs.io
 .. _imu sensor: https://www.dexterindustries.com/shop/imu-sensor/
 .. _light and color sensor: https://www.dexterindustries.com/shop/light-color-sensor/
 .. _temperature humidity pressure sensor: https://www.dexterindustries.com/shop/temperature-humidity-pressure-sensor/

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,13 +22,13 @@ For assembling your `GoPiGo3`_ robot, read the instructions from the following p
 Connecting to GoPiGo3
 ************************
 
-For connecting to your `GoPiGo3`_ robot with a computer or laptop, read the instructions on the following page: `connecting to robot`_.
+To connect to your `GoPiGo3`_ robot with a computer or laptop, read the instructions on the following page: `connecting to robot`_.
 
 ***********************
 Program your GoPiGo3
 ***********************
 
-For programming your `GoPiGo3`_ to do what you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
+To program your `GoPiGo3`_ to do what you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
 
 To install or update the `GoPiGo3`_ library on your RaspberryPi, open a terminal or the command line and type the following command:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -84,7 +84,7 @@ For more on getting started with these sensors, please check the `DI-Sensors`_ d
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories
-.. _DI-Sensors: http://di-sensors.readthedocs.io/en/latest/
+.. _DI-Sensors: http://di-sensors.readthedocs.io/en/master/
 .. _imu sensor: https://www.dexterindustries.com/shop/imu-sensor/
 .. _light and color sensor: https://www.dexterindustries.com/shop/light-color-sensor/
 .. _temperature humidity pressure sensor: https://www.dexterindustries.com/shop/temperature-humidity-pressure-sensor/

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -28,7 +28,38 @@ For connecting to your `GoPiGo3`_ robot with a computer or laptop, read the inst
 Program your GoPiGo3
 ***********************
 
-For programming your `GoPiGo3`_ to do anything you want, read the instructions found here: `programming your robot`_.
+For programming your `GoPiGo3`_ to do anything you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
+
+For installing/updating the `GoPiGo3`_ on your RaspberryPi, you have to open up a terminal and hit the following command:
+
+.. code-block:: bash
+
+   # follow any given instructions given through this command
+
+   sudo curl -kL dexterindustries.com/update_gopigo3 | bash
+
+Also, in order to be able to use the :py:meth:`easygopigo3.EasyGoPiGo3.init_distance_sensor` method and the :py:class:`easygopigo3.DistanceSensor` class, the `DI-Sensors`_ package is required.
+You can get it installed/updated by typing the following command:
+
+.. code-block:: bash
+
+   # follow any given instructions given through this command
+
+   sudo curl -kL dexterindustries.com/update_sensors | bash
+
+***********************
+Connecting More Sensors
+***********************
+
+The `GoPiGo3`_ can also be paired with our in-house made sensors.
+At the moment, we've got 4 sensors (one of which is already implemented in the GoPiGo3's package):
+
+   * The DI `IMU Sensor`_.
+   * The DI `Light and Color Sensor`_.
+   * The DI `Temperature Humidity Pressure Sensor`_.
+   * The DI `Distance Sensor`_.
+
+For more on getting started with these sensors, please check the `DI-Sensors`_ documentation.
 
 .. _gopigo3: https://www.dexterindustries.com/shop/gopigo-advanced-starter-kit/
 .. _assembling instructions: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/1-assemble-gopigo3/
@@ -53,3 +84,7 @@ For programming your `GoPiGo3`_ to do anything you want, read the instructions f
 .. _repository: https://www.dexterindustries.com/GoPiGo/get-started-with-the-gopigo3-raspberry-pi-robot/3-program-your-raspberry-pi-robot/python-programming-language/
 .. _raspbian for robots: https://sourceforge.net/projects/dexterindustriesraspbianflavor/
 .. _forum: http://forum.dexterindustries.com/categories
+.. _DI-Sensors: http://di-sensors.readthedocs.io/en/latest/
+.. _imu sensor: https://www.dexterindustries.com/shop/imu-sensor/
+.. _light and color sensor: https://www.dexterindustries.com/shop/light-color-sensor/
+.. _temperature humidity pressure sensor: https://www.dexterindustries.com/shop/temperature-humidity-pressure-sensor/

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -28,7 +28,7 @@ For connecting to your `GoPiGo3`_ robot with a computer or laptop, read the inst
 Program your GoPiGo3
 ***********************
 
-For programming your `GoPiGo3`_ to do anything you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
+For programming your `GoPiGo3`_ to do what you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
 
 To install or update the `GoPiGo3`_ library on your RaspberryPi, open a terminal or the command line and type the following command:
 
@@ -52,7 +52,7 @@ Connect More Sensors
 ********************
 
 The `GoPiGo3`_ can also be paired with our in-house sensors.
-There are a number of digital and analog sensor that can be connected to the GoPiGo3. We have further in-depth documentation on the following 4 sensors:
+There are a number of digital and analog sensors that can be connected to the GoPiGo3. We have further in-depth documentation on the following 4 sensors:
 
    * The DI `IMU Sensor`_.
    * The DI `Light and Color Sensor`_.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -30,7 +30,7 @@ Program your GoPiGo3
 
 For programming your `GoPiGo3`_ to do anything you want, you can follow the instructions found here (`programming your robot`_) or *follow the rest of instructions found in this section*.
 
-For installing/updating the `GoPiGo3`_ on your RaspberryPi, you have to open up a terminal and hit the following command:
+To install or update the `GoPiGo3`_ library on your RaspberryPi, open a terminal or the command line and type the following command:
 
 .. code-block:: bash
 
@@ -39,7 +39,7 @@ For installing/updating the `GoPiGo3`_ on your RaspberryPi, you have to open up 
    sudo curl -kL dexterindustries.com/update_gopigo3 | bash
 
 Also, in order to be able to use the :py:meth:`easygopigo3.EasyGoPiGo3.init_distance_sensor` method and the :py:class:`easygopigo3.DistanceSensor` class, the `DI-Sensors`_ package is required.
-You can get it installed/updated by typing the following command:
+You can install it or update it with the following command in the terminal:
 
 .. code-block:: bash
 
@@ -52,7 +52,7 @@ Connect More Sensors
 ********************
 
 The `GoPiGo3`_ can also be paired with our in-house sensors.
-At the moment, we've got 4 sensors (one of which is already implemented in the GoPiGo3's package):
+There are a number of digital and analog sensor that can be connected to the GoPiGo3. We have further in-depth documentation on the following 4 sensors:
 
    * The DI `IMU Sensor`_.
    * The DI `Light and Color Sensor`_.


### PR DESCRIPTION
A built version of the updated documentation can be found here: http://gopigo3-dev.readthedocs.io
The link I have provided leads to an unlisted RTD project.