### PR TITLE
raise error in line follower if the line follower is not connected

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -2326,6 +2326,7 @@ class LineFollower(Sensor):
         :param easygopigo3.EasyGoPiGo3 gpg = None: The :py:class:`~easygopigo3.EasyGoPiGo3` object that we need for instantiating this object.
         :raises ImportError: If the :py:mod:`line_follower` module couldn't be found.
         :raises TypeError: If the ``gpg`` parameter is not a :py:class:`~easygopigo3.EasyGoPiGo3` object.
+        :raises IOError: If the line follower is not responding.
 
 
         The only value the ``port`` parameter can take is ``"I2C"``.
@@ -2339,6 +2340,8 @@ class LineFollower(Sensor):
         try:
             self.set_descriptor("Line Follower")
             Sensor.__init__(self, port, "INPUT", gpg)
+            if line_sensor.read_sensor() == [-1, -1, -1, -1, -1]:
+                raise IOError("Line Follower not responding")
         except:
             raise
 
@@ -2352,10 +2355,10 @@ class LineFollower(Sensor):
         """
         five_vals = line_sensor.read_sensor()
 
-        if five_vals != -1:
+        if five_vals != [-1, -1, -1, -1, -1]:
             return five_vals
         else:
-            return [-1, -1, -1, -1, -1]
+            raise IOError("Line Follower not responding")
 
     def get_white_calibration(self):
         """


### PR DESCRIPTION
This is the change that's needed in easygopigo3 to handle the case where a line follower is not connected