### PR TITLE
Fix mutex

### DIFF
--- a/Software/Python/I2C_mutex.py
+++ b/Software/Python/I2C_mutex.py
@@ -11,29 +11,25 @@ class Mutex(object):
     def acquire(self):
         if self.mutex_debug:
             print("I2C mutex acquire")
-        while self.DexterLockI2C_handle is not None:
-            time.sleep(0.001)
-        DexterLockI2C_handle = True
-
-        try:
-            DexterLockI2C_handle = open('/run/lock/DexterLockI2C')
-        except:
-            pass
 
         acquired = False
         while not acquired:
             try:
+                self.DexterLockI2C_handle = open('/run/lock/DexterLockI2C', 'w')
                 # lock
-                fcntl.lockf(DexterLockI2C_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.lockf(self.DexterLockI2C_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
             except IOError: # already locked by a different process
                 time.sleep(0.001)
             except Exception as e:
                 print(e)
 
+	if self.mutex_debug:
+	    print("I2C mutex acquired {}".format(time.time()))
+
     def release(self):
         if self.mutex_debug:
-            print("I2C mutex release")
+            print("I2C mutex release: {}".format(time.time()))
         if self.DexterLockI2C_handle is not None and self.DexterLockI2C_handle is not True:
             self.DexterLockI2C_handle.close()
             self.DexterLockI2C_handle = None
@@ -51,6 +47,6 @@ class Mutex(object):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self.release()
         if self.mutex_debug:
             print("I2C mutex exit")
+        self.release()

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -89,10 +89,11 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
     """
 
-    def __init__(self):
+    def __init__(self, use_mutex = False):
         """
         | This constructor sets the variables to the following values:
 
+        :param bool use_mutex = False: When using multiple threads/processes that access the same resource/device, mutex has to be enabled.
         :var int speed = 300: The speed of the motors should go between **0-1000** DPS.
         :var tuple(int,int,int) left_eye_color = (0,255,255): Set Dex's left eye color to **turqoise**.
         :var tuple(int,int,int) right_eye_color = (0,255,255): Set Dex's right eye color to **turqoise**.
@@ -119,6 +120,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         self.set_speed(self.DEFAULT_SPEED)
         self.left_eye_color = (0, 255, 255)
         self.right_eye_color = (0, 255, 255)
+        self.use_mutex = use_mutex
 
     def volt(self):
         """
@@ -805,13 +807,12 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         return Servo(port, self)
 
-    def init_distance_sensor(self, port = "I2C", use_mutex=False):
+    def init_distance_sensor(self, port = "I2C"):
         """
 
         | Initialises a :py:class:`~easygopigo3.DistanceSensor` object and then returns it.
 
         :param str port = "I2C": The only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
-        :param bool use_mutex = False: When using multiple threads/processes that access the same resource/device, mutex has to be enabled.
         :returns: An instance of the :py:class:`~easygopigo3.DistanceSensor` class and with the port set to ``port``'s value.
 
         The ``"I2C"`` ports are mapped to the following :ref:`hardware-ports-section`.
@@ -825,14 +826,13 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
                 * The I2C devices are recognizeable by the `GoPiGo3`_ platform.
 
         """
-        return DistanceSensor(port, self, use_mutex)
+        return DistanceSensor(port, self, self.use_mutex)
 
-    def init_dht_sensor(self, sensor_type = 0, use_mutex=False):
+    def init_dht_sensor(self, sensor_type = 0):
         """
         | Initialises a :py:class:`~easygopigo3.DHTSensor` object and then returns it.
 
         :param int sensor_type = 0: Choose ``sensor_type = 0`` when you have the blue-coloured DHT sensor or ``sensor_type = 1`` when it's white.
-        :param bool use_mutex = False: When using multiple threads/processes that access the same resource/device, mutexes have to be used.
         :returns: An instance of the :py:class:`~easygopigo3.DHTSensor` class and with the port set to ``port``'s value.
 
         .. important::
@@ -843,7 +843,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
             The ``"SERIAL"`` port is mapped to the following :ref:`hardware-ports-section`.
 
         """
-        return DHTSensor(self, sensor_type, use_mutex)
+        return DHTSensor(self, sensor_type, self.use_mutex)
 
     def init_remote(self, port="AD1"):
         """
@@ -867,7 +867,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         The ``"AD1"`` port is mapped to the following :ref:`hardware-ports-section`.
         """
 
-        return MotionSensor(port,self)
+        return MotionSensor(port, self)
 
 # the following functions may be redundant
 
@@ -2348,7 +2348,7 @@ class LineFollower(Sensor):
         :returns: A list with 5 10-bit numbers that represent the readings from the line follower device.
         :rtype: list[int]
         :raises IOError: If the line follower is not responding.
-        
+
         """
         five_vals = line_sensor.read_sensor()
 

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -920,7 +920,7 @@ class Sensor(object):
     """
     PORTS = {}
 
-    def __init__(self, port, pinmode, gpg):
+    def __init__(self, port, pinmode, gpg, use_mutex=False):
         """
         Constructor for creating a connection to one of the available grove ports on the `GoPIGo3`_.
 
@@ -962,6 +962,7 @@ class Sensor(object):
         debug(pinmode)
         self.set_port(port)
         self.set_pin_mode(pinmode)
+        self.use_mutex = use_mutex
 
         try:
             # I2C sensors don't need a valid gpg
@@ -1151,10 +1152,10 @@ class Sensor(object):
 
 
 class DigitalSensor(Sensor):
-    def __init__(self, port, pinmode, gpg):
+    def __init__(self, port, pinmode, gpg, use_mutex = False):
         debug("DigitalSensor init")
         try:
-            Sensor.__init__(self, port, pinmode, gpg)
+            Sensor.__init__(self, port, pinmode, gpg, use_mutex)
         except:
             raise
 
@@ -1216,7 +1217,7 @@ class AnalogSensor(Sensor):
         With this class, both analog sensors and actuators (output devices such as LEDs which may require controlled output voltages) can be connected.
 
     """
-    def __init__(self, port, pinmode, gpg):
+    def __init__(self, port, pinmode, gpg, use_mutex = False):
         """
         Binds an analog device to the specified ``port`` with the appropriate ``pinmode`` mode.
 
@@ -1244,7 +1245,7 @@ class AnalogSensor(Sensor):
         self.freq = 24000
         self._max_value = 4096
         try:
-            Sensor.__init__(self, port, pinmode, gpg)
+            Sensor.__init__(self, port, pinmode, gpg, use_mutex)
         except:
             raise
 
@@ -1373,7 +1374,7 @@ class LightSensor(AnalogSensor):
          For more sensors, please see our Dexter Industries `shop`_.
 
     """
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.LightSensor` object for the `Grove Light Sensor`_.
 
@@ -1392,7 +1393,7 @@ class LightSensor(AnalogSensor):
         debug("LightSensor init")
         self.set_descriptor("Light sensor")
         try:
-            AnalogSensor.__init__(self, port, "INPUT", gpg)
+            AnalogSensor.__init__(self, port, "INPUT", gpg, use_mutex)
         except:
             raise
         self.set_pin(1)
@@ -1439,7 +1440,7 @@ class SoundSensor(AnalogSensor):
          For more sensors, please see our Dexter Industries `shop`_.
 
     """
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex=False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.SoundSensor` object for the `Grove Sound Sensor`_.
 
@@ -1458,7 +1459,7 @@ class SoundSensor(AnalogSensor):
         debug("Sound Sensor on port " + port)
         self.set_descriptor("Sound sensor")
         try:
-            AnalogSensor.__init__(self, port, "INPUT", gpg)
+            AnalogSensor.__init__(self, port, "INPUT", gpg, use_mutex)
         except:
             raise
         self.set_pin(1)
@@ -1506,7 +1507,7 @@ class LoudnessSensor(AnalogSensor):
          For more sensors, please see our Dexter Industries `shop`_.
 
     """
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex=False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.LoudnessSensor` object for the `Grove Loudness Sensor`_.
 
@@ -1525,7 +1526,7 @@ class LoudnessSensor(AnalogSensor):
         debug("Loudness Sensor on port " + port)
         self.set_descriptor("Loudness sensor")
         try:
-            AnalogSensor.__init__(self, port, "INPUT", gpg)
+            AnalogSensor.__init__(self, port, "INPUT", gpg, use_mutex)
         except:
             raise
         self.set_pin(1)
@@ -1578,7 +1579,7 @@ class UltraSonicSensor(AnalogSensor):
 
     """
 
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.UltraSonicSensor` object for the `Grove Ultrasonic Sensor`_.
 
@@ -1597,7 +1598,7 @@ class UltraSonicSensor(AnalogSensor):
 
         try:
             debug("Ultrasonic Sensor on port " + port)
-            AnalogSensor.__init__(self, port, "US", gpg)
+            AnalogSensor.__init__(self, port, "US", gpg, use_mutex)
             self.set_descriptor("Ultrasonic sensor")
             self.safe_distance = 500
             self.set_pin(1)
@@ -1829,7 +1830,7 @@ class Buzzer(AnalogSensor):
              "G5": 784,
              "G5#": 831}
 
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.Buzzer` object for the `Grove Buzzer`_.
 
@@ -1849,7 +1850,7 @@ class Buzzer(AnalogSensor):
         """
 
         try:
-            AnalogSensor.__init__(self, port, "OUTPUT", gpg)
+            AnalogSensor.__init__(self, port, "OUTPUT", gpg, use_mutex)
             self.set_pin(1)
             self.set_descriptor("Buzzer")
             self.power = 50
@@ -1970,7 +1971,7 @@ class Led(AnalogSensor):
 
 
     """
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.Led` object for the `Grove LED`_.
 
@@ -1988,7 +1989,7 @@ class Led(AnalogSensor):
         """
         try:
             self.set_descriptor("LED")
-            AnalogSensor.__init__(self, port, "OUTPUT", gpg)
+            AnalogSensor.__init__(self, port, "OUTPUT", gpg, use_mutex)
             self.set_pin(1)
         except:
             raise
@@ -2081,7 +2082,7 @@ class MotionSensor(DigitalSensor):
 
     """
 
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.MotionSensor` object for the `Grove Motion Sensor`_.
 
@@ -2099,7 +2100,7 @@ class MotionSensor(DigitalSensor):
         """
         try:
             self.set_descriptor("Motion Sensor")
-            DigitalSensor.__init__(self, port, "DIGITAL_INPUT", gpg)
+            DigitalSensor.__init__(self, port, "DIGITAL_INPUT", gpg, use_mutex)
             self.set_pin(1)
         except:
             raise
@@ -2160,7 +2161,7 @@ class ButtonSensor(DigitalSensor):
 
     """
 
-    def __init__(self, port="AD1", gpg=None):
+    def __init__(self, port="AD1", gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.ButtonSensor` object for the `Grove Button`_.
 
@@ -2178,7 +2179,7 @@ class ButtonSensor(DigitalSensor):
         """
         try:
             self.set_descriptor("Button sensor")
-            DigitalSensor.__init__(self, port, "DIGITAL_INPUT", gpg)
+            DigitalSensor.__init__(self, port, "DIGITAL_INPUT", gpg, use_mutex)
             self.set_pin(1)
         except:
             raise
@@ -2220,7 +2221,7 @@ class Remote(Sensor):
     #: the actual symbols we see on the `Infrared Remote`_.
     keycodes = ["up", "left", "ok", "right","down","1","2","3","4","5","6","7", "8","9","*","0","#"]
 
-    def __init__(self, port="AD1",gpg=None):
+    def __init__(self, port="AD1",gpg=None, use_mutex = False):
         """
         Constructor for initializing a :py:class:`~easygopigo3.Remote` object.
 
@@ -2233,7 +2234,7 @@ class Remote(Sensor):
         """
         try:
             self.set_descriptor("Remote Control")
-            Sensor.__init__(self, port, "IR", gpg)
+            Sensor.__init__(self, port, "IR", gpg, use_mutex)
         except:
             raise
 
@@ -2314,7 +2315,7 @@ class LineFollower(Sensor):
 
     """
 
-    def __init__(self, port="I2C", gpg=None):
+    def __init__(self, port="I2C", gpg=None, use_mutex=False):
         """
         Constructor for initalizing a :py:class:`~easygopigo3.LineFollower` object.
 
@@ -2335,7 +2336,7 @@ class LineFollower(Sensor):
 
         try:
             self.set_descriptor("Line Follower")
-            Sensor.__init__(self, port, "INPUT", gpg)
+            Sensor.__init__(self, port, "INPUT", gpg, use_mutex)
             if line_sensor.read_sensor() == [-1, -1, -1, -1, -1]:
                 raise IOError("Line Follower not responding")
         except:
@@ -2485,7 +2486,7 @@ class Servo(Sensor):
 
     """
 
-    def __init__(self, port="SERVO1", gpg=None):
+    def __init__(self, port="SERVO1", gpg=None, use_mutex=False):
         """
         Constructor for instantiating a :py:class:`~easygopigo3.Servo` object for a (or multiple) `servo`_ (servos).
 
@@ -2503,7 +2504,7 @@ class Servo(Sensor):
         """
         try:
             self.set_descriptor("GoPiGo3 Servo")
-            Sensor.__init__(self, port, "OUTPUT", gpg)
+            Sensor.__init__(self, port, "OUTPUT", gpg, use_mutex)
         except:
             raise
 
@@ -2607,11 +2608,9 @@ class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
         """
         self.set_descriptor("Distance Sensor")
         try:
-            Sensor.__init__(self, port, "OUTPUT", gpg)
+            Sensor.__init__(self, port, "OUTPUT", gpg, use_mutex)
         except:
             raise
-
-        self.use_mutex = use_mutex
 
         _ifMutexAcquire(self.use_mutex)
         try:
@@ -2750,11 +2749,10 @@ class DHTSensor(Sensor):
             self.set_descriptor("White DHT Sensor")
 
         try:
-            Sensor.__init__(self,port,"INPUT",gpg)
+            Sensor.__init__(self,port,"INPUT",gpg, use_mutex)
         except:
             raise
 
-        self.use_mutex = use_mutex
 
     def read_temperature(self):
         """

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -10,7 +10,7 @@ import time
 import os
 from I2C_mutex import Mutex
 
-mutex = Mutex()
+mutex = Mutex(debug=True)
 
 def _ifMutexAcquire(mutex_enabled = False):
     """
@@ -2651,7 +2651,8 @@ class DistanceSensor(Sensor, distance_sensor.DistanceSensor):
             _ifMutexAcquire(self.use_mutex)
             try:
                 mm = self.read_range_single()
-            except:
+            except Exception as e:
+                print(e)
                 mm = 0
             finally:
                 _ifMutexRelease(self.use_mutex)

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -10,7 +10,7 @@ import time
 import os
 from I2C_mutex import Mutex
 
-mutex = Mutex(debug=True)
+mutex = Mutex(debug=False)
 
 def _ifMutexAcquire(mutex_enabled = False):
     """

--- a/Software/Python/tests/test_distance_sensor.py
+++ b/Software/Python/tests/test_distance_sensor.py
@@ -1,0 +1,18 @@
+import time
+import easygopigo3 as easy
+gpg = easy.EasyGoPiGo3(use_mutex=True)
+
+my_Distance_portI2C = easy.DistanceSensor('I2C', gpg, use_mutex=True)
+time.sleep(0.1)
+
+
+# start()
+while True:
+        dist =  my_Distance_portI2C.read_mm()
+	print(dist)
+        if dist == 0:
+		exit()
+        else:
+		print(".")
+        time.sleep(0.1)
+

--- a/Software/Python/tests/test_distance_sensor.py
+++ b/Software/Python/tests/test_distance_sensor.py
@@ -1,3 +1,10 @@
+####################################################
+# This file contains a short test to determine
+#     if it is possible to access the distance sensor
+#     from two separate processes using mutex.
+# Run in parallel with test_distance_sensor_2.py
+####################################################
+
 import time
 import easygopigo3 as easy
 gpg = easy.EasyGoPiGo3(use_mutex=True)

--- a/Software/Python/tests/test_distance_sensor_2.py
+++ b/Software/Python/tests/test_distance_sensor_2.py
@@ -1,0 +1,18 @@
+import time
+import easygopigo3 as easy
+gpg = easy.EasyGoPiGo3(use_mutex=True)
+
+my_Distance_portI2C = easy.DistanceSensor('I2C', gpg, use_mutex=True)
+time.sleep(0.1)
+
+
+# start()
+while True:
+        dist =  my_Distance_portI2C.read_mm()
+	print(dist)
+        if dist == 0:
+		exit()
+        else:
+		print(".")
+        time.sleep(0.1)
+

--- a/Software/Python/tests/test_distance_sensor_2.py
+++ b/Software/Python/tests/test_distance_sensor_2.py
@@ -1,3 +1,10 @@
+####################################################
+# This file contains a short test to determine
+#     if it is possible to access the distance sensor
+#     from two separate processes using mutex.
+# Run in parallel with test_distance_sensor.py
+####################################################
+
 import time
 import easygopigo3 as easy
 gpg = easy.EasyGoPiGo3(use_mutex=True)

--- a/Software/Python/tests/test_heavy_mutex.py
+++ b/Software/Python/tests/test_heavy_mutex.py
@@ -1,0 +1,25 @@
+####################################################
+# This file tests the mutex class
+# Run it in parallel with text_heavy_mutext_2.py
+# in order to verify that mutex is functional.
+# This one acquires and releases every half second
+# the other one is every 5 seconds
+####################################################
+import time
+from I2C_mutex import Mutex
+import fcntl
+
+mutex = Mutex(debug=True)
+
+DexterLockI2C_handle = open('/run/lock/DexterLockI2C')
+
+while True:
+    try:
+        mutex.acquire()
+        time.sleep(0.5)
+        mutex.release()
+    except KeyboardInterrupt:
+        mutex.release()
+        exit(0)
+    except Exception as e:
+        print(e)

--- a/Software/Python/tests/test_heavy_mutex_2.py
+++ b/Software/Python/tests/test_heavy_mutex_2.py
@@ -1,0 +1,25 @@
+####################################################
+# This file tests the mutex class
+# Run it in parallel with text_heavy_mutext_2.py
+# in order to verify that mutex is functional.
+# This one acquires and releases every 5 seconds
+# the other one is every half second
+####################################################
+import time
+from I2C_mutex import Mutex
+import fcntl
+
+mutex = Mutex(debug=True)
+
+DexterLockI2C_handle = open('/run/lock/DexterLockI2C')
+
+while True:
+    try:
+        mutex.acquire()
+        time.sleep(5)
+    	mutex.release()
+    except KeyboardInterrupt:
+        mutex.release()
+        exit()
+    except Exception as e:
+        print(e)

--- a/Software/Python/tests/test_mutex.py
+++ b/Software/Python/tests/test_mutex.py
@@ -1,0 +1,38 @@
+####################################################
+# This file attempts to create one of each sensor and
+#   sets its mutex use to True.
+# As the use_mutex is a member of the base Sensor class,
+#    we check if the info is passed down properly.
+# It does not test whether mutex is properly used inside each sensor.
+# In fact some sensors will make no use of it at all
+# (on GPG3 some sensors do not require mutex)
+# Nicole Parrot
+####################################################
+
+import easygopigo3 as easy
+
+g = easy.EasyGoPiGo3(use_mutex=True)
+
+light_sensor = easy.LightSensor(gpg=g, use_mutex = True)
+buzzer = easy.Buzzer(gpg=g, use_mutex = True)
+led = easy.Led(gpg=g, use_mutex = True)
+motion = easy.MotionSensor(gpg=g, use_mutex = True)
+button = easy.ButtonSensor(gpg=g, use_mutex = True)
+remote = easy.Remote(gpg=g, use_mutex = True)
+line_follower = easy.LineFollower(gpg=g, use_mutex = True)
+servo = easy.Servo(gpg=g, use_mutex = True)
+distance_sensor = easy.DistanceSensor(gpg=g, use_mutex = True)
+dht = easy.DHTSensor(gpg=g, use_mutex = True)
+assert(g.use_mutex == True)
+assert(light_sensor.use_mutex == True)
+assert(buzzer.use_mutex == True)
+assert(led.use_mutex == True)
+assert(motion.use_mutex == True)
+assert(button.use_mutex == True)
+assert(remote.use_mutex == True)
+assert(line_follower.use_mutex == True)
+assert(servo.use_mutex == True)
+assert(distance_sensor.use_mutex == True)
+assert(dht.use_mutex == True)
+print("Done")
+


### PR DESCRIPTION
Keep track of use_mutex in the base Sensor class.
Adjust all init methods to pass down use_mutex
Keep all init methods the same as what is in easygopigo.
Add a test file to ensure that we are indeed instantiating each sensor and passing down the use_mutex value properly. This test file is almost identical to the one in GoPiGo (except for library name)

See https://github.com/DexterInd/GoPiGo/pull/277