### PR TITLE
hotfix - docs badge updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GoPiGo3 [![Documentation Status](https://readthedocs.org/projects/gopigo3/badge/?version=latest)](http://gopigo3.readthedocs.io/en/latest/?badge=latest)
+# GoPiGo3 [![Documentation Status](https://readthedocs.org/projects/gopigo3/badge/?version=master)](http://gopigo3.readthedocs.io/en/latest/?badge=master)
 
 The GoPiGo3 is a delightful and complete robot for the Raspberry Pi that turns your Pi into a fully operating robot.  GoPiGo3 is a mobile robotic platform for the Raspberry Pi developed by [Dexter Industries.](http://www.dexterindustries.com/GoPiGo)
 


### PR DESCRIPTION
The default version of the documentation has been changed and now we point to master.
As of this moment, we get an *Unknown documentation* error on our repo like in the following screenshot:
![badge_unknown](https://user-images.githubusercontent.com/26958764/32119775-facddd9c-bb5e-11e7-870f-339d54ad89fb.PNG)
This PR solves this issue.