### PR TITLE
small fix in I2C_Mutex

### DIFF
--- a/Software/Python/I2C_mutex.py
+++ b/Software/Python/I2C_mutex.py
@@ -21,7 +21,8 @@ def I2C_Mutex_Acquire():
 
 def I2C_Mutex_Release():
     global DexterLockI2C_handle
-    if DexterLockI2C_handle is not None:
+    if DexterLockI2C_handle is not None and \
+       DexterLockI2C_handle is not True:
         DexterLockI2C_handle.close()
         DexterLockI2C_handle = None
         time.sleep(0.001)


### PR DESCRIPTION
There is a tiny infinitesimal chance that DexterLockI2C_handle is equal to True, so let's handle this case.

([happened to at least one person](https://forum.dexterindustries.com/t/solved-distance-sensor-error/3822))