### PR TITLE
hotfix - root/non-root mechanism for installing/updating the gopigo3

### DIFF
--- a/Install/README.md
+++ b/Install/README.md
@@ -27,9 +27,13 @@ sudo reboot
 
 ## Quick Install
 
-Instead of cloning the repository and then running the install script, you can just enter the following command and then reboot your Raspberry Pi:
+Instead of cloning the repository and then running the install script, you can just enter one of the following 2 commands and then reboot your Raspberry Pi:
 ```
-sudo curl -kL dexterindustries.com/update_gopigo3 | bash
+# for installing the python packages with root permissions (except anything else which will ran as root) run this
+sudo sh -c "curl -kL dexterindustries.com/update_gopigo3 | bash"
+
+# for installing the python packages with user permissions (except anything else which will ran as root) run this
+curl -kL dexterindustries.com/update_gopigo3 | bash
 ```
 
 ## Test and Troubleshooting

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -2,7 +2,6 @@
 
 if [[ $EUID -ne 0 ]]; then
     echo "Script ran without root privileges: not installing python packages."
-    exit 1
 fi
 
 SCRIPTDIR="$(readlink -f $(dirname $0))"

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 if [[ $EUID -ne 0 ]]; then
-    echo "This script must be run as root"
+    echo "Script ran without root privileges: not installing python packages."
     exit 1
 fi
 
@@ -54,9 +54,9 @@ SERVICEFILE=$REPO_PATH/Install/gpg3_power.service # This should be changed to th
 SCRIPTFILE=$REPO_PATH/Install/gpg3_power.sh
 SERVICECOMMAND=" ExecStart=/usr/bin/env bash "
 # Remove line 8 from the service file, the default location of the Service File
-sed -i '6d' $SERVICEFILE
+sudo sed -i '6d' $SERVICEFILE
 # Add new path and file name of gpg3_power.sh to the service file
-sed -i "6i $SERVICECOMMAND $SCRIPTFILE" $SERVICEFILE
+sudo sed -i "6i $SERVICECOMMAND $SCRIPTFILE" $SERVICEFILE
 
 # Install the system services
 sudo cp $REPO_PATH/Install/gpg3_power.service /etc/systemd/system
@@ -89,22 +89,22 @@ if grep -q "#dtparam=spi=on" /boot/config.txt; then
 elif grep -q "dtparam=spi=on" /boot/config.txt; then
     echo "SPI already enabled"
 else
-    echo 'dtparam=spi=on' >> /boot/config.txt
+    sudo sh -c "echo 'dtparam=spi=on' >> /boot/config.txt"
     echo "SPI enabled"
 fi
 
 echo ""
 cd $REPO_PATH/Software/Python/
-sudo python setup.py install
-sudo python3 setup.py install
+python setup.py install
+python3 setup.py install
 
 # module for interfacing with the keyboard
-sudo pip3 install curtsies
-sudo pip3 install numpy
-sudo pip3 install python-periphery
-sudo pip install curtsies
-sudo pip install numpy
-sudo pip install python-periphery
+pip3 install curtsies
+pip3 install numpy
+pip3 install python-periphery
+pip install curtsies
+pip install numpy
+pip install python-periphery
 
 echo ""
 echo "Installation complete"

--- a/Install/update_gopigo3.sh
+++ b/Install/update_gopigo3.sh
@@ -13,7 +13,7 @@ if folder_exists "$GOPIGO3_DIR" ; then
     echo "GoPiGo3 Directory Exists"
     cd $DEXTER_PATH/GoPiGo3    # Go to directory
     sudo git fetch origin       # Hard reset the git files
-    sudo git reset --hard  
+    sudo git reset --hard
     sudo git merge origin/master
     # change_branch $BRANCH
 else
@@ -23,4 +23,4 @@ else
     # change_branch $BRANCH  # change to a branch we're working on, if we've defined the branch above.
 fi
 
-sudo bash /home/pi/Dexter/GoPiGo3/Install/install.sh
+bash /home/pi/Dexter/GoPiGo3/Install/install.sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
 
 2. For installing the python packages of the `GoPiGo3` without root privileges (except any other settings that can come with), use the following command:
 ```
-curl -kL dexterindustris.com/update_tools | bash
+curl -kL dexterindustries.com/update_tools | bash
 ```
 The same command can be used for updating the `GoPiGo3` to the latest version.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ In order to quick install the `GoPiGo3` repository, open up a terminal and type 
 
 1. For installing the python packages of the `GoPiGo3` with root privileges (except any other settings that can come with), use the following command:
 ```
-sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
+sudo sh -c "curl -kL dexterindustries.com/update_gopigo3 | bash"
 ```
 
 2. For installing the python packages of the `GoPiGo3` without root privileges (except any other settings that can come with), use the following command:
 ```
-curl -kL dexterindustries.com/update_tools | bash
+curl -kL dexterindustries.com/update_gopigo3 | bash
 ```
 The same command can be used for updating the `GoPiGo3` to the latest version.
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,22 @@ You can install the GoPiGo3 on your own operating system with the following comm
 1. Clone this repository onto the Raspberry Pi:
 
         sudo git clone http://www.github.com/DexterInd/GoPiGo3.git /home/pi/Dexter/GoPiGo3
-        
+
 2. Run the install script: `sudo bash /home/pi/Dexter/GoPiGo3/Install/install.sh`
 3. Reboot the Raspberry Pi to make the settings take effect: `sudo reboot`
 
 
 # Quick Install
-In order to quick install the `GoPiGo3` repository, open up a terminal and type the following command:
+In order to quick install the `GoPiGo3` repository, open up a terminal and type one of the 2 following commands:
+
+1. For installing the python packages of the `GoPiGo3` with root privileges (except any other settings that can come with), use the following command:
 ```
-sudo curl -kL dexterindustries.com/update_gopigo3 | bash
+sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
+```
+
+2. For installing the python packages of the `GoPiGo3` without root privileges (except any other settings that can come with), use the following command:
+```
+curl -kL dexterindustris.com/update_tools | bash
 ```
 The same command can be used for updating the `GoPiGo3` to the latest version.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -36,7 +36,7 @@ To install or update the `GoPiGo3`_ library on your RaspberryPi, open a terminal
 
    # follow any given instructions given through this command
 
-   sudo curl -kL dexterindustries.com/update_gopigo3 | bash
+   sudo sh -c "curl -kL dexterindustries.com/update_gopigo3 | bash"
 
 Also, in order to be able to use the :py:meth:`easygopigo3.EasyGoPiGo3.init_distance_sensor` method and the :py:class:`easygopigo3.DistanceSensor` class, the `DI-Sensors`_ package is required.
 You can install it or update it with the following command in the terminal:
@@ -45,7 +45,7 @@ You can install it or update it with the following command in the terminal:
 
    # follow any given instructions given through this command
 
-   sudo curl -kL dexterindustries.com/update_sensors | bash
+   sudo sh -c "curl -kL dexterindustries.com/update_sensors | bash"
 
 ********************
 Connect More Sensors


### PR DESCRIPTION
This should make the GoPiGo3 update/install with or without privileges the python package(s).

For updating/installing the python packages of the GoPiGo3 **with** su privileges the user will run:
```
# this
sudo sh -c "curl -kL dexterindustries.com/update_gopigo3 | bash"

# or this
curl -kL dexterindustries.com/update_gopigo3 > update_gopigo3.sh
sudo bash update_gopigo3.sh
```
For updating/installing the python packages of the GoPiGo3 **without** su privileges the user will run:
```
curl -kL dexterindustries.com/update_gopigo3 | bash
```

Further tests are still required before accepting this PR.