### PR TITLE
small change to documentation

### DIFF
--- a/docs/source/api-advanced.rst
+++ b/docs/source/api-advanced.rst
@@ -13,7 +13,6 @@ Before using this chapter's classes, you need to be able to import the following
 .. code-block:: python
 
    import easygopigo3
-   import gopigo3
 
 If you have issues importing these 2 modules, then make sure that:
 

--- a/docs/source/api-advanced.rst
+++ b/docs/source/api-advanced.rst
@@ -22,7 +22,7 @@ If you have issues importing this module, then make sure that:
 
 If you encounter issues that aren't covered by our :ref:`Getting Started <getting-started-chapter>` guide or :ref:`FAQ <faq-chapter>` chapter, please head over to our `forum`_.
 
-Take note that the easygopigo3 module depends on the underlying gopigo3 module.  The base gopigo3 module contains lower level calls that would allow you finer control over your GoPiGo3 and its functionality is available to you once easygopigo3 is imported.
+Take note that the ``easygopigo3`` module depends on the underlying ``gopigo3`` module.  The base ``gopigo3`` module contains lower level calls that would allow you finer control over your GoPiGo3 and its functionality is available to you once ``easygopigo3`` is imported.
 
 =====================================
 Sensor

--- a/docs/source/api-advanced.rst
+++ b/docs/source/api-advanced.rst
@@ -8,19 +8,21 @@ API GoPiGo3 - Advanced
 Requirements
 ============
 
-Before using this chapter's classes, you need to be able to import the following modules.
+Before using this chapter's classes, you need to be able to import the following module.
 
 .. code-block:: python
 
    import easygopigo3
 
-If you have issues importing these 2 modules, then make sure that:
+If you have issues importing this module, then make sure that:
 
    * You've followed the steps found in :ref:`Getting Started <getting-started-chapter>` guide.
    * You have installed either `Raspbian For Robots`_, the GoPiGo3 `repository`_ or the `GoPiGo3 package`_ (the pip package).
    * You have the ``gopigo3`` package installed by typing the command ``pip freeze | grep gopigo3`` on your Raspberry Pi's terminal. If the package is installed, then a string with the ``gopigo3==[x.y.z]`` format will show up.
 
 If you encounter issues that aren't covered by our :ref:`Getting Started <getting-started-chapter>` guide or :ref:`FAQ <faq-chapter>` chapter, please head over to our `forum`_.
+
+Take note that the easygopigo3 module depends on the underlying gopigo3 module.  The base gopigo3 module contains lower level calls that would allow you finer control over your GoPiGo3 and its functionality is available to you once easygopigo3 is imported.
 
 =====================================
 Sensor


### PR DESCRIPTION
: if importing easygopigo3, then importing gopigo3 is not required