### PR TITLE
fix - adding missing dep to remotebot project

### DIFF
--- a/Projects/RemoteCameraRobot/install.sh
+++ b/Projects/RemoteCameraRobot/install.sh
@@ -35,4 +35,4 @@ echo "Restarting UV4L service"
 service uv4l_raspicam restart
 
 echo "Installing Flask"
-apt-get -y install python3-flask
+apt-get -y install python3-flask wiringpi


### PR DESCRIPTION
`wiringpi` seems to be needed on raspbian. I had encountered this when I tried to run the browser bot.