### PR TITLE
CMake build configuration for C++ library

### DIFF
--- a/Software/C/CMakeLists.txt
+++ b/Software/C/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gopigo3_cpp)
+
+include_directories(.)
+
+### GoPiGo3 library
+add_library(gopigo3 SHARED GoPiGo3.cpp)
+
+### Examples
+
+# grove_led
+add_executable(grove_led Examples/grove_led.cpp)
+target_link_libraries(grove_led gopigo3)
+
+# i2c
+add_executable(i2c Examples/i2c.cpp)
+target_link_libraries(i2c gopigo3)
+
+# info
+add_executable(info Examples/info.cpp)
+target_link_libraries(info gopigo3)
+
+# leds
+add_executable(leds Examples/leds.cpp)
+target_link_libraries(leds gopigo3)
+
+# motors
+add_executable(motors Examples/motors.cpp)
+target_link_libraries(motors gopigo3)
+
+# sensors
+add_executable(sensors Examples/sensors.cpp)
+target_link_libraries(sensors gopigo3)

--- a/Software/C/CMakeLists.txt
+++ b/Software/C/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(gopigo3_cpp)
 
+### Build
+
 include_directories(.)
 
-### GoPiGo3 library
+## GoPiGo3 library
 add_library(gopigo3 SHARED GoPiGo3.cpp)
 
-### Examples
+## Examples
 
 # grove_led
 add_executable(grove_led Examples/grove_led.cpp)
@@ -31,3 +33,42 @@ target_link_libraries(motors gopigo3)
 # sensors
 add_executable(sensors Examples/sensors.cpp)
 target_link_libraries(sensors gopigo3)
+
+### Installation
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN "Examples" EXCLUDE
+)
+
+install(TARGETS gopigo3 EXPORT gopigo3Targets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+### Export CMake configuration
+
+set_property(TARGET gopigo3 APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/>
+)
+
+set(CONF_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/)
+
+export(EXPORT gopigo3Targets
+  FILE "${PROJECT_BINARY_DIR}/gopigo3_cppTargets.cmake")
+
+configure_file(gopigo3_cppConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/gopigo3_cppConfig.cmake" @ONLY)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/gopigo3_cppConfig.cmake"
+  DESTINATION share/gopigo3_cpp/cmake)
+
+install(EXPORT gopigo3Targets
+  FILE gopigo3_cppTargets.cmake
+  DESTINATION share/gopigo3_cpp/cmake
+)

--- a/Software/C/Examples/grove_led.cpp
+++ b/Software/C/Examples/grove_led.cpp
@@ -8,12 +8,12 @@
  *
  *  This is an example for using an ultrasonic sensor and IR receiver with the GoPiGo3.
  *
- *  Hardware: Connect a grove ultrasonic sensor to GPG3 AD1 port, and IR receiver to GPG3 AD2 port.
+ *  Hardware: Connect a grove LED to GPG3 AD1 port.
  *
- *  Results:  When you run this program, you should see the values for each sensor.
+ *  Results:  When you run this program, you should see the grove LED brightness pulsing up and down.
  *
  *  Example compile command:
- *    g++ -o program "sensors.c"
+ *    g++ -o program "grove_led.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -30,19 +30,21 @@ void exit_signal_handler(int signo);
 
 int main(){
   signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
-  
+
   GPG.detect(); // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
-  
-  GPG.set_grove_type(GROVE_1, GROVE_TYPE_US);
-  GPG.set_grove_type(GROVE_2, GROVE_TYPE_IR_DI_REMOTE);
-  sensor_ultrasonic_t US;
-  sensor_infrared_gobox_t IR;
-  
+
+  GPG.set_grove_type(GROVE_1, GROVE_TYPE_CUSTOM);
+  GPG.set_grove_mode(GROVE_1_1, OUTPUT_PWM);
+
+  int8_t i = 0;
+  int8_t a = 1;
   while(true){
-    int USerror = GPG.get_grove_value(GROVE_1, &US);
-    int IRerror = GPG.get_grove_value(GROVE_2, &IR);
-    printf("US: Error %d  %4dmm    IR: Error %d  button %d\n", USerror, US.mm, IRerror, IR.button);
-    usleep(20000);
+    GPG.set_grove_pwm_duty(GROVE_1_1, i);
+    i += a;
+    if(i == 100 || i == 0){
+      a *= -1;
+    }
+    usleep(5000);
   }
 }
 

--- a/Software/C/Examples/grove_led.cpp
+++ b/Software/C/Examples/grove_led.cpp
@@ -13,13 +13,13 @@
  *  Results:  When you run this program, you should see the grove LED brightness pulsing up and down.
  *
  *  Example compile command:
- *    g++ -o program "grove_led.cpp"
+ *    g++ -o grove_led grove_led.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./grove_led
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>    // for GoPiGo3
 #include <stdio.h>      // for printf
 #include <unistd.h>     // for usleep
 #include <signal.h>     // for catching exit signals

--- a/Software/C/Examples/i2c.cpp
+++ b/Software/C/Examples/i2c.cpp
@@ -13,13 +13,13 @@
  *  Results:  When you run this program, P0 output should toggle.
  *
  *  Example compile command:
- *    g++ -o program "i2c.cpp"
+ *    g++ -o i2c i2c.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./i2c
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>    // for GoPiGo3
 #include <stdio.h>      // for printf
 #include <unistd.h>     // for usleep
 #include <signal.h>     // for catching exit signals

--- a/Software/C/Examples/i2c.cpp
+++ b/Software/C/Examples/i2c.cpp
@@ -6,14 +6,14 @@
  *  Released under the MIT license (http://choosealicense.com/licenses/mit/).
  *  For more information see https://github.com/DexterInd/GoPiGo3/blob/master/LICENSE.md
  *
- *  This is an example for using an ultrasonic sensor and IR receiver with the GoPiGo3.
+ *  This is an example for using I2C with the GoPiGo3.
  *
- *  Hardware: Connect a grove LED to GPG3 AD1 port.
+ *  Hardware: Connect a PCA9570 I2C output expander to GPG3 AD1 port.
  *
- *  Results:  When you run this program, you should see the grove LED brightness pulsing up and down.
+ *  Results:  When you run this program, P0 output should toggle.
  *
  *  Example compile command:
- *    g++ -o program "grove_led.c"
+ *    g++ -o program "i2c.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -30,21 +30,25 @@ void exit_signal_handler(int signo);
 
 int main(){
   signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
-  
+
   GPG.detect(); // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
-  
-  GPG.set_grove_type(GROVE_1, GROVE_TYPE_CUSTOM);
-  GPG.set_grove_mode(GROVE_1_1, OUTPUT_PWM);
-  
-  int8_t i = 0;
-  int8_t a = 1;
+
+  GPG.set_grove_type(GROVE_1, GROVE_TYPE_I2C);
+  i2c_struct_t I2C1;
+  I2C1.address = 0x24;
+  I2C1.length_read = 3;
+  I2C1.length_write = 1;
+  uint8_t s = 0;
   while(true){
-    GPG.set_grove_pwm_duty(GROVE_1_1, i);
-    i += a;
-    if(i == 100 || i == 0){
-      a *= -1;
+    I2C1.buffer_write[0] = s;
+    int error = GPG.grove_i2c_transfer(GROVE_1, &I2C1);
+    printf("Error: %d  bytes: %d %d %d\n", error, I2C1.buffer_read[0], I2C1.buffer_read[1], I2C1.buffer_read[2]);
+    if(s == 0){
+      s = 1;
+    }else{
+      s = 0;
     }
-    usleep(5000);
+    usleep(50000);
   }
 }
 

--- a/Software/C/Examples/info.cpp
+++ b/Software/C/Examples/info.cpp
@@ -11,7 +11,7 @@
  *  Results: Print information about the attached GoPiGo3.
  *
  *  Example compile command:
- *    g++ -o program "info.c"
+ *    g++ -o program "info.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -24,27 +24,27 @@ GoPiGo3 GPG; // Create a GoPiGo3 instance
 
 int main(){
   char str[33]; // Room for the 32-character serial number string plus the NULL terminator.
-  
+
   // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
   // pass 'false' to detect() to make the error non-critical (return the error instead of exiting the program).
   if(GPG.detect(false) == ERROR_NONE){
     printf("\nGoPiGo3 info:\n");
-    
+
     GPG.get_manufacturer(str);
     printf("  Manufacturer    : %s\n", str);
-    
+
     GPG.get_board(str);
     printf("  Board           : %s\n", str);
-    
+
     GPG.get_id(str);
     printf("  Serial Number   : %s\n", str);
-    
+
     GPG.get_version_hardware(str);
     printf("  Hardware version: %s\n", str);
-    
+
     GPG.get_version_firmware(str);
     printf("  Firmware version: %s\n", str);
-    
+
     printf("  Battery voltage : %.3f\n", GPG.get_voltage_battery());
     printf("  5v voltage      : %.3f\n", GPG.get_voltage_5v());
   }else{

--- a/Software/C/Examples/info.cpp
+++ b/Software/C/Examples/info.cpp
@@ -11,13 +11,13 @@
  *  Results: Print information about the attached GoPiGo3.
  *
  *  Example compile command:
- *    g++ -o program "info.cpp"
+ *    g++ -o info info.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./info
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>   // for GoPiGo3
 #include <stdio.h>     // for printf
 
 GoPiGo3 GPG; // Create a GoPiGo3 instance

--- a/Software/C/Examples/leds.cpp
+++ b/Software/C/Examples/leds.cpp
@@ -11,13 +11,13 @@
  *  Results:  When you run this program, you should see the encoder value for each motor. Manually rotate the left motor, and the right motor will follow.
  *
  *  Example compile command:
- *    g++ -o program "leds.cpp"
+ *    g++ -o leds leds.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./leds
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>   // for GoPiGo3
 #include <stdio.h>     // for printf
 #include <unistd.h>    // for usleep
 #include <signal.h>    // for catching exit signals

--- a/Software/C/Examples/leds.cpp
+++ b/Software/C/Examples/leds.cpp
@@ -11,7 +11,7 @@
  *  Results:  When you run this program, you should see the encoder value for each motor. Manually rotate the left motor, and the right motor will follow.
  *
  *  Example compile command:
- *    g++ -o program "leds.c"
+ *    g++ -o program "leds.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -30,9 +30,9 @@ void exit_signal_handler(int signo);
 
 int main(){
   signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
-  
+
   GPG.detect(); // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
-  
+
   uint8_t i1 = 0;
   uint8_t i2 = BRIGHTNESS_LIMIT / 3;
   uint8_t i3 = (BRIGHTNESS_LIMIT * 2) / 3;
@@ -44,7 +44,7 @@ int main(){
     GPG.set_led(LED_EYE_RIGHT, i2, i3, i1);
     GPG.set_led(LED_BLINKER_LEFT, i1);
     GPG.set_led(LED_BLINKER_RIGHT, i2);
-    
+
     i1 += a1;
     if(i1 == BRIGHTNESS_LIMIT || i1 == 0){
       a1 *= -1;
@@ -57,7 +57,7 @@ int main(){
     if(i3 == BRIGHTNESS_LIMIT || i3 == 0){
       a3 *= -1;
     }
-    
+
     // slow down
     usleep(25000);
   }

--- a/Software/C/Examples/motors.cpp
+++ b/Software/C/Examples/motors.cpp
@@ -11,7 +11,7 @@
  *  Results:  When you run this program, you should see the encoder value for each motor. Manually rotate the left motor, and the right motor will follow.
  *
  *  Example compile command:
- *    g++ -o program "motors.c"
+ *    g++ -o program "motors.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -28,24 +28,24 @@ void exit_signal_handler(int signo);
 
 int main(){
   signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
-  
+
   GPG.detect(); // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
-  
+
   // Reset the encoders
   GPG.offset_motor_encoder(MOTOR_LEFT, GPG.get_motor_encoder(MOTOR_LEFT));
   GPG.offset_motor_encoder(MOTOR_RIGHT, GPG.get_motor_encoder(MOTOR_RIGHT));
-  
+
   while(true){
     // Read the encoders
     int32_t EncoderLeft = GPG.get_motor_encoder(MOTOR_LEFT);
     int32_t EncoderRight = GPG.get_motor_encoder(MOTOR_RIGHT);
-    
+
     // Use the encoder value from the left motor to control the position of the right motor
     GPG.set_motor_position(MOTOR_RIGHT, EncoderLeft);
-    
+
     // Display the encoder values
     printf("Encoder Left: %6d  Right: %6d\n", EncoderLeft, EncoderRight);
-    
+
     // Delay for 20ms
     usleep(20000);
   }

--- a/Software/C/Examples/motors.cpp
+++ b/Software/C/Examples/motors.cpp
@@ -11,13 +11,13 @@
  *  Results:  When you run this program, you should see the encoder value for each motor. Manually rotate the left motor, and the right motor will follow.
  *
  *  Example compile command:
- *    g++ -o program "motors.cpp"
+ *    g++ -o motors motors.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./motors
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>   // for GoPiGo3
 #include <stdio.h>     // for printf
 #include <unistd.h>    // for usleep
 #include <signal.h>    // for catching exit signals

--- a/Software/C/Examples/sensors.cpp
+++ b/Software/C/Examples/sensors.cpp
@@ -13,13 +13,13 @@
  *  Results:  When you run this program, you should see the values for each sensor.
  *
  *  Example compile command:
- *    g++ -o program "sensors.cpp"
+ *    g++ -o sensors sensors.cpp ../GoPiGo3.cpp -I..
  *  Example run command:
- *    sudo ./program
+ *    sudo ./sensors
  *
  */
 
-#include "GoPiGo3.cpp" // for GoPiGo3
+#include <GoPiGo3.h>    // for GoPiGo3
 #include <stdio.h>      // for printf
 #include <unistd.h>     // for usleep
 #include <signal.h>     // for catching exit signals

--- a/Software/C/Examples/sensors.cpp
+++ b/Software/C/Examples/sensors.cpp
@@ -6,14 +6,14 @@
  *  Released under the MIT license (http://choosealicense.com/licenses/mit/).
  *  For more information see https://github.com/DexterInd/GoPiGo3/blob/master/LICENSE.md
  *
- *  This is an example for using I2C with the GoPiGo3.
+ *  This is an example for using an ultrasonic sensor and IR receiver with the GoPiGo3.
  *
- *  Hardware: Connect a PCA9570 I2C output expander to GPG3 AD1 port.
+ *  Hardware: Connect a grove ultrasonic sensor to GPG3 AD1 port, and IR receiver to GPG3 AD2 port.
  *
- *  Results:  When you run this program, P0 output should toggle.
+ *  Results:  When you run this program, you should see the values for each sensor.
  *
  *  Example compile command:
- *    g++ -o program "i2c.c"
+ *    g++ -o program "sensors.cpp"
  *  Example run command:
  *    sudo ./program
  *
@@ -30,25 +30,19 @@ void exit_signal_handler(int signo);
 
 int main(){
   signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
-  
+
   GPG.detect(); // Make sure that the GoPiGo3 is communicating and that the firmware is compatible with the drivers.
-  
-  GPG.set_grove_type(GROVE_1, GROVE_TYPE_I2C);
-  i2c_struct_t I2C1;
-  I2C1.address = 0x24;
-  I2C1.length_read = 3;
-  I2C1.length_write = 1;
-  uint8_t s = 0;
+
+  GPG.set_grove_type(GROVE_1, GROVE_TYPE_US);
+  GPG.set_grove_type(GROVE_2, GROVE_TYPE_IR_DI_REMOTE);
+  sensor_ultrasonic_t US;
+  sensor_infrared_gobox_t IR;
+
   while(true){
-    I2C1.buffer_write[0] = s;
-    int error = GPG.grove_i2c_transfer(GROVE_1, &I2C1);
-    printf("Error: %d  bytes: %d %d %d\n", error, I2C1.buffer_read[0], I2C1.buffer_read[1], I2C1.buffer_read[2]);
-    if(s == 0){
-      s = 1;
-    }else{
-      s = 0;
-    }
-    usleep(50000);
+    int USerror = GPG.get_grove_value(GROVE_1, &US);
+    int IRerror = GPG.get_grove_value(GROVE_2, &IR);
+    printf("US: Error %d  %4dmm    IR: Error %d  button %d\n", USerror, US.mm, IRerror, IR.button);
+    usleep(20000);
   }
 }
 

--- a/Software/C/GoPiGo3.cpp
+++ b/Software/C/GoPiGo3.cpp
@@ -113,7 +113,7 @@ int GoPiGo3::detect(bool critical){
       return ERROR_WRONG_MANUFACTURER;
     }
   }
-  
+
   // assign error to the value returned by get_board, and if not 0:
   if(error = get_board(str)){
     if(critical){
@@ -129,7 +129,7 @@ int GoPiGo3::detect(bool critical){
       return ERROR_WRONG_DEVICE;
     }
   }
-  
+
   // assign error to the value returned by get_version_firmware, and if not 0:
   if(error = get_version_firmware(str)){
     if(critical){
@@ -295,16 +295,16 @@ int GoPiGo3::get_motor_status(uint8_t port, uint8_t &state, int8_t &power, int32
   if(int error = spi_transfer_array(12, spi_array_out, spi_array_in)){
     return error;
   }
-  
+
   if(spi_array_in[3] != 0xA5){
     return ERROR_SPI_RESPONSE;
   }
-  
+
   state    = spi_array_in[4];
   power    = spi_array_in[5];
   position = ((spi_array_in[6] << 24) | (spi_array_in[7] << 16) | (spi_array_in[8] << 8) | spi_array_in[9]);
   dps      = ((spi_array_in[10] << 8) | spi_array_in[11]);
-  
+
   return ERROR_NONE;
 }
 
@@ -410,7 +410,7 @@ int GoPiGo3::grove_i2c_transfer(uint8_t port, i2c_struct_t *i2c_struct){
       Continue = true;
     }
   }
-  
+
   double DelayTime = 0;
   if(i2c_struct->length_write){
     DelayTime += 1 + i2c_struct->length_write;
@@ -422,7 +422,7 @@ int GoPiGo3::grove_i2c_transfer(uint8_t port, i2c_struct_t *i2c_struct){
   // No point trying to read the values before they are ready.
   usleep((DelayTime * 1000000)); // delay for as long as it will take to do the I2C transaction.
   Timeout = get_time() + 0.005;  // timeout after 5ms of failed attempted reads
-  
+
   while(true){
     if(error = get_grove_value(port, i2c_struct)){
       if(get_time() >= Timeout){
@@ -452,27 +452,27 @@ int GoPiGo3::grove_i2c_start(uint8_t port, i2c_struct_t *i2c_struct){
   spi_array_out[0] = Address;
   spi_array_out[1] = msg_type;
   spi_array_out[2] = ((i2c_struct->address & 0x7F) << 1);
-  
+
   if(i2c_struct->length_read > LONGEST_I2C_TRANSFER){
     i2c_struct->length_read = LONGEST_I2C_TRANSFER;
   }
   spi_array_out[3] = i2c_struct->length_read;
   GroveI2CInBytes[port_index] = i2c_struct->length_read;
-  
+
   if(i2c_struct->length_write > LONGEST_I2C_TRANSFER){
     i2c_struct->length_write = LONGEST_I2C_TRANSFER;
   }
   spi_array_out[4] = i2c_struct->length_write;
-  
+
   for(uint8_t i = 0; i < i2c_struct->length_write; i++){
     spi_array_out[5 + i] = i2c_struct->buffer_write[i];
   }
-  
+
   // assign error to the value returned by spi_transfer_array, and if not 0:
   if(int error = spi_transfer_array((5 + i2c_struct->length_write), spi_array_out, spi_array_in)){
     return error;
   }
-  
+
   // If the fourth byte received is not 0xA5
   if(spi_array_in[3] != 0xA5){
     return ERROR_SPI_RESPONSE;
@@ -481,7 +481,7 @@ int GoPiGo3::grove_i2c_start(uint8_t port, i2c_struct_t *i2c_struct){
   if(spi_array_in[4] != GROVE_STATUS_VALID_DATA){
     return spi_array_in[4];
   }
-  
+
   return ERROR_NONE;
 }
 
@@ -502,9 +502,9 @@ int GoPiGo3::get_grove_value(uint8_t port, void *value_ptr){
   }
   spi_array_out[0] = Address;
   spi_array_out[1] = msg_type;
-  
+
   uint8_t spi_transfer_length;
-  
+
   // Determine the SPI transaction byte length based on the grove type
   switch(GroveType[port_index]){
     case GROVE_TYPE_IR_DI_REMOTE:
@@ -523,7 +523,7 @@ int GoPiGo3::get_grove_value(uint8_t port, void *value_ptr){
       return GROVE_STATUS_NOT_CONFIGURED;
     break;
   }
-  
+
   // Get the grove value(s), and if error
   // assign error to the value returned by spi_transfer_array, and if not 0:
   if(int error = spi_transfer_array(spi_transfer_length, spi_array_out, spi_array_in)){
@@ -542,7 +542,7 @@ int GoPiGo3::get_grove_value(uint8_t port, void *value_ptr){
   if(spi_array_in[5] != GROVE_STATUS_VALID_DATA){
     return spi_array_in[5];
   }
-  
+
   if(GroveType[port_index] == GROVE_TYPE_IR_DI_REMOTE){
     sensor_infrared_gobox_t *Value = (sensor_infrared_gobox_t*)value_ptr;
     Value->button = spi_array_in[6];

--- a/Software/C/GoPiGo3.cpp
+++ b/Software/C/GoPiGo3.cpp
@@ -9,7 +9,7 @@
  *  C++ drivers for the GoPiGo3
  */
 
-#include "GoPiGo3.h"
+#include <GoPiGo3.h>
 
 GoPiGo3::GoPiGo3(){
   if(spi_file_handle < 0){

--- a/Software/C/GoPiGo3.h
+++ b/Software/C/GoPiGo3.h
@@ -30,6 +30,7 @@
 #include <string.h>           // for strstr
 #include <sys/time.h>         // for clock_gettime
 #include <unistd.h>
+#include <stdexcept>
 
 // Error values
 #define ERROR_NONE                  0
@@ -77,9 +78,7 @@ int spi_transfer_array(uint8_t length, uint8_t *outArray, uint8_t *inArray){
 
 // Function to call if an error occured that can not be resolved, such as failure to set up SPI
 void fatal_error(const char *error){
-  printf(error);
-  printf("\n");
-  exit(-1);
+  throw std::runtime_error(error);
 }
 
 //struct timespec _time;

--- a/Software/C/GoPiGo3.h
+++ b/Software/C/GoPiGo3.h
@@ -71,15 +71,8 @@ int spi_transfer_array(uint8_t length, uint8_t *outArray, uint8_t *inArray){
   if (ioctl(spi_file_handle, SPI_IOC_MESSAGE(1), &spi_xfer_struct) < 0) {
     return ERROR_SPI_FILE;
   }
-  
-  return ERROR_NONE;
-}
 
-// Function to call if an error occured that can not be resolved, such as failure to set up SPI
-void fatal_error(char *error){
-  printf(error);
-  printf("\n");
-  exit(-1);
+  return ERROR_NONE;
 }
 
 // Function to call if an error occured that can not be resolved, such as failure to set up SPI

--- a/Software/C/GoPiGo3.h
+++ b/Software/C/GoPiGo3.h
@@ -50,16 +50,16 @@ uint8_t spi_array_in[LONGEST_SPI_TRANSFER];  // SPI in array
 // Set up SPI. Open the file, and define the configuration.
 int spi_setup(){
   spi_file_handle = open(SPIDEV_FILE_NAME, O_RDWR);
-  
+
   if (spi_file_handle < 0){
     return ERROR_SPI_FILE;
   }
-  
+
   spi_xfer_struct.cs_change = 0;               // Keep CS activated
   spi_xfer_struct.delay_usecs = 0;             // delay in us
   spi_xfer_struct.speed_hz = SPI_TARGET_SPEED; // speed
   spi_xfer_struct.bits_per_word = 8;           // bites per word 8
-  
+
   return ERROR_NONE;
 }
 
@@ -68,7 +68,7 @@ int spi_transfer_array(uint8_t length, uint8_t *outArray, uint8_t *inArray){
   spi_xfer_struct.len = length;
   spi_xfer_struct.tx_buf = (unsigned long)outArray;
   spi_xfer_struct.rx_buf = (unsigned long)inArray;
-  
+
   if (ioctl(spi_file_handle, SPI_IOC_MESSAGE(1), &spi_xfer_struct) < 0) {
     return ERROR_SPI_FILE;
   }
@@ -91,44 +91,44 @@ double get_time(){
 
 enum GPGSPI_MESSAGE_TYPE{
   GPGSPI_MESSAGE_NONE,
-  
+
   GPGSPI_MESSAGE_GET_MANUFACTURER,
   GPGSPI_MESSAGE_GET_NAME,
   GPGSPI_MESSAGE_GET_HARDWARE_VERSION,
   GPGSPI_MESSAGE_GET_FIRMWARE_VERSION,
   GPGSPI_MESSAGE_GET_ID,
-  
+
   GPGSPI_MESSAGE_SET_LED,
-  
+
   GPGSPI_MESSAGE_GET_VOLTAGE_5V,
   GPGSPI_MESSAGE_GET_VOLTAGE_VCC,
-  
+
   GPGSPI_MESSAGE_SET_SERVO,
-  
+
   GPGSPI_MESSAGE_SET_MOTOR_PWM,
-  
+
   GPGSPI_MESSAGE_SET_MOTOR_POSITION,
   GPGSPI_MESSAGE_SET_MOTOR_POSITION_KP,
   GPGSPI_MESSAGE_SET_MOTOR_POSITION_KD,
-  
+
   GPGSPI_MESSAGE_SET_MOTOR_DPS,
-  
+
   GPGSPI_MESSAGE_SET_MOTOR_LIMITS,
-  
+
   GPGSPI_MESSAGE_OFFSET_MOTOR_ENCODER,
-  
+
   GPGSPI_MESSAGE_GET_MOTOR_ENCODER_LEFT,
   GPGSPI_MESSAGE_GET_MOTOR_ENCODER_RIGHT,
-  
+
   GPGSPI_MESSAGE_GET_MOTOR_STATUS_LEFT,
   GPGSPI_MESSAGE_GET_MOTOR_STATUS_RIGHT,
-  
+
   GPGSPI_MESSAGE_SET_GROVE_TYPE,
   GPGSPI_MESSAGE_SET_GROVE_MODE,
   GPGSPI_MESSAGE_SET_GROVE_STATE,
   GPGSPI_MESSAGE_SET_GROVE_PWM_DUTY,
   GPGSPI_MESSAGE_SET_GROVE_PWM_FREQUENCY,
-  
+
   GPGSPI_MESSAGE_GET_GROVE_VALUE_1,
   GPGSPI_MESSAGE_GET_GROVE_VALUE_2,
   GPGSPI_MESSAGE_GET_GROVE_STATE_1_1,
@@ -143,7 +143,7 @@ enum GPGSPI_MESSAGE_TYPE{
   GPGSPI_MESSAGE_GET_GROVE_ANALOG_1_2,
   GPGSPI_MESSAGE_GET_GROVE_ANALOG_2_1,
   GPGSPI_MESSAGE_GET_GROVE_ANALOG_2_2,
-  
+
   GPGSPI_MESSAGE_START_GROVE_I2C_1,
   GPGSPI_MESSAGE_START_GROVE_I2C_2
 };
@@ -238,10 +238,10 @@ class GoPiGo3{
   public:
   // Set up the GoPiGo3
     GoPiGo3();
-    
+
   // Confirm that the BrickPi3 is connected and up-to-date
     int     detect(bool critical = true);
-    
+
   // Get the manufacturer (should be "Dexter Industries")
     int     get_manufacturer(char *str);
   // Get the board name (should be "BrickPi3")
@@ -252,10 +252,10 @@ class GoPiGo3{
     int     get_version_firmware(char *str);
   // Get the serial number ID that is unique to each BrickPi3
     int     get_id(char *str);
-    
+
   // Control the LED
     int     set_led(uint8_t led, uint8_t red, uint8_t green = 0, uint8_t blue = 0);
-    
+
   // Get the voltages of the four power rails
     // Get the voltage and return as floating point voltage
     float   get_voltage_5v     ();
@@ -263,10 +263,10 @@ class GoPiGo3{
     // Pass the pass-by-reference float variable where the voltage will be stored. Returns the error code.
     int     get_voltage_5v     (float &voltage);
     int     get_voltage_battery(float &voltage);
-    
+
   // Set a servo position in microseconds
     int     set_servo(uint8_t servo, uint16_t us);
-  
+
   // Set the motor PWM power
     int     set_motor_power(uint8_t port, int8_t power);
   // Set the motor target position to run to (go to the specified position)
@@ -284,8 +284,8 @@ class GoPiGo3{
     int     get_motor_encoder(uint8_t port, int32_t &value);
     // Pass the port. Returns the encoder value.
     int32_t get_motor_encoder(uint8_t port);
-    
-    
+
+
   // Configure grove pin(s)/port(s)
     // Set grove port type
     int      set_grove_type(uint8_t port, uint8_t type);
@@ -318,17 +318,17 @@ class GoPiGo3{
     uint16_t get_grove_analog(uint8_t pin);
     // get value with pass-by-reference, and return error code
     int      get_grove_analog(uint8_t pin, uint16_t &value);
-    
+
   // Reset the grove ports (unconfigure), motors (float with no limits), and LEDs.
     int     reset_all();
-    
+
   private:
     // GoPiGo3 SPI address
     uint8_t Address;
-    
+
     uint8_t GroveType[2];
     uint8_t GroveI2CInBytes[2];
-    
+
     int spi_read_8 (uint8_t msg_type, uint8_t  &value);
     int spi_read_16(uint8_t msg_type, uint16_t &value);
     int spi_read_32(uint8_t msg_type, uint32_t &value);

--- a/Software/C/gopigo3_cppConfig.cmake.in
+++ b/Software/C/gopigo3_cppConfig.cmake.in
@@ -1,0 +1,16 @@
+# - Config file for the GOPIGO3 package
+# It defines the following variables
+#  GOPIGO3_INCLUDE_DIRS - include directories for gopigo3_cpp
+#  GOPIGO3_LIBRARIES    - libraries to link against
+
+# Compute paths
+get_filename_component(GOPIGO3_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(GOPIGO3_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET gopigo3 AND NOT GOPIGO3_BINARY_DIR)
+  include("${GOPIGO3_CMAKE_DIR}/gopigo3_cppTargets.cmake")
+endif()
+
+# These are IMPORTED targets created by gopigo3_cppTargets.cmake
+set(GOPIGO3_LIBRARIES gopigo3)

--- a/Software/C/package.xml
+++ b/Software/C/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gopigo3_cpp</name>
+  <version>0.0.0</version>
+  <description>C++ driver for GoPiGo3</description>
+
+  <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
+
+  <license>MIT</license>
+
+  <url type="website">https://www.dexterindustries.com/gopigo3/</url>
+  <url type="website">https://github.com/DexterInd/GoPiGo3</url>
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This PR fixes the examples to include the GoPiGo3 header instead of the source file, cleans up `GoPiGo3.h` to only contain public functions used by examples, and adds a CMake build configuration and a ROS package definition.

Commits:
- renames example files from *.c to *.cpp
- moves function implementations to `GoPiGo3.cpp`
- moves internal function definitions (not used by examples) to `GoPiGo3.cpp`
- includes `GoPiGo3.h` in all examples and compiles with `GoPiGo3.cpp`
- adds a CMake build configuration for the library and examples
- adds a ROS package definition