### PR TITLE
Add reset_motor_encoder

### DIFF
--- a/Software/C/GoPiGo3.cpp
+++ b/Software/C/GoPiGo3.cpp
@@ -163,7 +163,7 @@ int GoPiGo3::get_version_hardware(char *str){
   if(int error = spi_read_32(GPGSPI_MESSAGE_GET_HARDWARE_VERSION, value)){
     return error;
   }
-  sprintf(str, "%d.%d.%d", (value / 1000000), ((value / 1000) % 1000), (value % 1000));
+  sprintf(str, "%d.x.x", (value / 1000000));
 }
 
 int GoPiGo3::get_version_firmware(char *str){

--- a/Software/C/GoPiGo3.h
+++ b/Software/C/GoPiGo3.h
@@ -12,10 +12,10 @@
 #ifndef GoPiGo3_h_
 #define GoPiGo3_h_
 
-#define FIRMWARE_VERSION_REQUIRED "0.3." // Firmware version needs to start with this
+#define FIRMWARE_VERSION_REQUIRED "1.0." // Firmware version needs to start with this
 
-#define LONGEST_I2C_TRANSFER 16 // longest possible I2C read/write
-#define LONGEST_SPI_TRANSFER 24 // spi_read_string 20 chars (LONGEST_I2C_TRANSFER + 6) // longest possible message for configuring for an I2C sensor
+#define LONGEST_I2C_TRANSFER 32 // longest possible I2C read/write
+#define LONGEST_SPI_TRANSFER (LONGEST_I2C_TRANSFER + 6) // at least 24 for spi_read_string 20 chars, and at least LONGEST_I2C_TRANSFER + 6 for I2C transactions
 
 #define SPI_TARGET_SPEED 500000 // SPI target speed of 500kbps
 

--- a/Software/Python/gopigo3.py
+++ b/Software/Python/gopigo3.py
@@ -583,6 +583,19 @@ class GoPiGo3(object):
                     ((offset >> 24) & 0xFF), ((offset >> 16) & 0xFF), ((offset >> 8) & 0xFF), (offset & 0xFF)]
         self.spi_transfer_array(outArray)
 
+    def reset_motor_encoder(self, port):
+        """
+        Reset a motor encoder to 0
+
+        Keyword arguments:
+        port -- The motor port(s). MOTOR_LEFT and/or MOTOR_RIGHT.
+        """
+        if port & self.MOTOR_LEFT:
+            self.offset_motor_encoder(self.MOTOR_LEFT, self.get_motor_encoder(self.MOTOR_LEFT))
+
+        if port & self.MOTOR_RIGHT:
+            self.offset_motor_encoder(self.MOTOR_RIGHT, self.get_motor_encoder(self.MOTOR_RIGHT))
+
     def set_grove_type(self, port, type):
         """
         Set grove type


### PR DESCRIPTION
Add reset_motor_encoder to gopigo3.py as a simpler way to reset the encoders.