### PR TITLE
hotfix - mock I2C_mutex file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['spidev', 'fcntl']
+MOCK_MODULES = ['spidev', 'fcntl', 'I2C_mutex']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
This doesn't have to be merged back into the dev branch as the dev branch follows a different route.

This fixes the documentation which no longer gets built, because `I2C_mutex` file has been removed in https://github.com/DexterInd/GoPiGo3/pull/165.