### PR TITLE
remove old libraries

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -93,6 +93,10 @@ else
 fi
 
 echo ""
+
+# remove old libraries, otherwise Mutex is taken from there instead
+sudo rm /usr/local/lib/python2.7/dist-packages/gopigo3*.egg
+sudo rm /usr/local/lib/python3.4/dist-packages/gopigo3*.egg
 cd $REPO_PATH/Software/Python/
 python setup.py install --force
 python3 setup.py install --force


### PR DESCRIPTION
current DI Update leads to broken GoPiGo3 libraries.
I2C_Mutex used to be in easygopigo3 but now it's in its own library. However, old I2C_mutex was still being called from old libraries still around. 
