### PR TITLE
fix - browser bot project

### DIFF
--- a/Projects/RemoteCameraRobot/README.md
+++ b/Projects/RemoteCameraRobot/README.md
@@ -28,7 +28,7 @@ You should now have everything set up.
 
 Start the server by typing the following command:
 ```
-sudo python3 flask_server.py
+python3 flask_server.py
 ```
 It's going to take a couple of seconds for the server to fire up.
 A port and address will be shown in there. By default, the port is set to `5000`.

--- a/Projects/RemoteCameraRobot/install.sh
+++ b/Projects/RemoteCameraRobot/install.sh
@@ -6,23 +6,24 @@
 
 echo "Checking if code name distribution is jessie/stretch"
 OS_CODENAME="$(lsb_release --codename --short)"
-if [[ $OS_CODENAME != "stretch" ]]; then
+if [[ $OS_CODENAME != "stretch" && $OS_CODENAME != "jessie" ]]; then
   echo "Code name distribution mismatch"
-  echo "Only Stretch is supported - older versions like Jessie or Wheezy are no longer maintained"
+  echo "Only Stretch and Jessie version are supported - soon enough, Jessie will no longer be supported as UV4L no longer maintains the project for Jessie"
   exit 1
 fi
 
 echo "Found $OS_CODENAME distribution"
 
-echo "Adding repository location for UV4L"
-curl -s http://www.linux-projects.org/listing/uv4l_repo/lrkey.asc | sudo apt-key add - > /dev/null
-if grep -q "[# ]*deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" /etc/apt/sources.list
-then
-    sed -i '/deb http:\/\/www\.linux-projects\.org\/listing\/uv4l_repo\/raspbian\/stretch stretch main/s/^#//' /etc/apt/sources.list
+# for stretch and jessie there are different sources
+if [[ $OS_CODENAME == "stretch" ]]; then
+  RELATIVE_PATH_SRC="stretch"
 else
-    echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" >> /etc/apt/sources.list
+  RELATIVE_PATH_SRC=""
 fi
 
+echo "Adding repository location for UV4L"
+curl -s http://www.linux-projects.org/listing/uv4l_repo/lrkey.asc | sudo apt-key add - > /dev/null
+echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/$RELATIVE_PATH_SRC $OS_CODENAME main" >> /etc/apt/sources.list
 
 echo "Updating repository"
 apt-get update

--- a/Projects/RemoteCameraRobot/install.sh
+++ b/Projects/RemoteCameraRobot/install.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 
-echo "Checking if code name distribution is jessie"
-CODE_NAME_DIST="$(lsb_release --codename)"
-if [[ $CODE_NAME_DIST != *"jessie" ]]; then
+# check https://www.linux-projects.org/uv4l/installation/ for more information
+# jessie/wheezy versions of UV4L are no longer maintained and hence
+# it's recommended to run this on a stretch
+
+echo "Checking if code name distribution is jessie/stretch"
+OS_CODENAME="$(lsb_release --codename --short)"
+if [[ $OS_CODENAME != "stretch" ]]; then
   echo "Code name distribution mismatch"
-  echo "Found "$CODE_NAME_DIST
+  echo "Only Stretch is supported - older versions like Jessie or Wheezy are no longer maintained"
   exit 1
-else
-  echo "Found jessie distribution"
 fi
+
+echo "Found $OS_CODENAME distribution"
 
 echo "Adding repository location for UV4L"
 curl -s http://www.linux-projects.org/listing/uv4l_repo/lrkey.asc | sudo apt-key add - > /dev/null
-if grep -q "[# ]*deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/ jessie main" /etc/apt/sources.list
+if grep -q "[# ]*deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" /etc/apt/sources.list
 then
-    sed -i '/deb http:\/\/www\.linux-projects\.org\/listing\/uv4l_repo\/raspbian\/ jessie main/s/^#//' /etc/apt/sources.list
+    sed -i '/deb http:\/\/www\.linux-projects\.org\/listing\/uv4l_repo\/raspbian\/stretch stretch main/s/^#//' /etc/apt/sources.list
 else
-    echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/ jessie main" >> /etc/apt/sources.list
+    echo -e "deb http://www.linux-projects.org/listing/uv4l_repo/raspbian/stretch stretch main" >> /etc/apt/sources.list
 fi
 
 
 echo "Updating repository"
-apt-get update > /dev/null
+apt-get update
 
 echo "Installing UV4L drivers"
 apt-get -y install uv4l uv4l-raspicam

--- a/Projects/RemoteCameraRobot/install_startup.sh
+++ b/Projects/RemoteCameraRobot/install_startup.sh
@@ -1,5 +1,5 @@
 # Installation file to make the Camera Robot start on boot.
-# This will add the camerarobot start on boot to SystemD on Jessie/Stretch
+# This will add the camerarobot start on boot to SystemD on Stretch
 
 sudo cp camerarobot.service /etc/systemd/system/
 sudo chmod 644 /etc/systemd/system/camerarobot.service

--- a/Projects/RemoteCameraRobot/templates/index.html
+++ b/Projects/RemoteCameraRobot/templates/index.html
@@ -15,7 +15,9 @@
 
     <div class="container">
         <div id="zone_joystick">
-            <img id="video_source" src="http://dex.local:8080/stream/video.mjpeg"/>
+          <script language="JavaScript">
+            document.write('<img id="video_source" src="' + window.location.protocol + '//' + window.location.hostname + ':8080' + '/stream/video.mjpeg' + '"/>' );
+          </script>
 
             <!--
             Example of video source shown on the whole page
@@ -45,7 +47,7 @@
         var joystick_size_factor = 1280;
         var joystick_default_size = 150;
         var joystick_current_size = joystick_default_size * width / joystick_size_factor;
-        var server_address = "http://dex.local:5000/robot";
+        var server_address = window.location.protocol + "//" + window.location.host + "/robot";
 
         // the data that's transformed as a query and sent to the server
         // changes while the joystick is used


### PR DESCRIPTION
My initial attempt was at making the browser bot work with the older packages from Jessie, since a quick search told me there's no support for Stretch for UV4L just yet - quite recent posts on various forums.

Unfortunately, I got into security and package incompatibility issues and that made me rethink the strategy as it had felt like a dead-end. Then I decided to dive a little more into seeing if there's someone who succeeded to make this work and surprisingly, I found that support for Stretch has just arrived not long ago. I used the new sources and it now works. 

The only caveat is that older versions for distributions such as jessie and wheezy are no longer maintained, but I don't think that's going to affect us in any way.