### PR TITLE
hotfix - remove a duplicate function in the docs

### DIFF
--- a/docs/source/api-basic/structure.rst
+++ b/docs/source/api-basic/structure.rst
@@ -232,7 +232,6 @@ Base Sensor
   easysensors.AnalogSensor
   easysensors.AnalogSensor.read
   easysensors.AnalogSensor.percent_read
-  easysensors.AnalogSensor.read
   easysensors.AnalogSensor.write_freq
 
 .. _distance sensor: https://www.dexterindustries.com/shop/distance-sensor/


### PR DESCRIPTION
Removing a duplicate in the documentation.