### PR TITLE
feature - add kill power method for the servo

### DIFF
--- a/Software/Python/easysensors.py
+++ b/Software/Python/easysensors.py
@@ -1583,11 +1583,11 @@ class Servo(Sensor):
         """
         self.rotate_servo(90)
 
-    def kill_servo(self):
+    def disable_servo(self):
         """
-        Kill the power to the `servo`_. 
+        Disable (or "float") the `servo`_. 
         
-        The effect of this command is that if you then try to rotate the servo manually, it won't resist you, thus meaning that it's not powered.
+        The effect of this command is that if you then try to rotate the servo manually, it won't resist you, thus meaning that it's not trying to hold a target position.
         """
         self.gpg.set_servo(self.portID, 0)
 

--- a/Software/Python/easysensors.py
+++ b/Software/Python/easysensors.py
@@ -1583,6 +1583,14 @@ class Servo(Sensor):
         """
         self.rotate_servo(90)
 
+    def kill_servo(self):
+        """
+        Kill the power to the `servo`_. 
+        
+        The effect of this command is that if you then try to rotate the servo manually, it won't resist you, thus meaning that it's not powered.
+        """
+        self.gpg.set_servo(self.portID, 0)
+
 
 class DHTSensor(Sensor):
     """

--- a/docs/source/api-basic/structure.rst
+++ b/docs/source/api-basic/structure.rst
@@ -191,7 +191,7 @@ Sensor/Actuator
    easysensors.Servo
    easysensors.Servo.rotate_servo
    easysensors.Servo.reset_servo
-   easysensors.Servo.kill_servo
+   easysensors.Servo.disable_servo
    easysensors.Remote
    easysensors.Remote.read
    easysensors.Remote.get_remote_code

--- a/docs/source/api-basic/structure.rst
+++ b/docs/source/api-basic/structure.rst
@@ -191,6 +191,7 @@ Sensor/Actuator
    easysensors.Servo
    easysensors.Servo.rotate_servo
    easysensors.Servo.reset_servo
+   easysensors.Servo.kill_servo
    easysensors.Remote
    easysensors.Remote.read
    easysensors.Remote.get_remote_code


### PR DESCRIPTION
Add a simple method to avoid making complex-and-hard-to-understand calls to disable a servo. Also, document it with docstrings. 