### PR TITLE
Fix/firmware flashing

### DIFF
--- a/Firmware/gopigo3_flash_firmware.sh
+++ b/Firmware/gopigo3_flash_firmware.sh
@@ -9,7 +9,7 @@ FIRMWARE_FILE=$(sudo find "$REPO_PATH"/Firmware/ -maxdepth 1 -name *.bin)
 echo "Updating the GoPiGo3 Firmware with '$FIRMWARE_FILE'."
 
 # check the RPi version
-RPI_VERSION=$(python -c "import auto_detect_rpi; print auto_detect_rpi.getRPIGenerationCode()")
+RPI_VERSION=$(python3 -c "import auto_detect_rpi; print (auto_detect_rpi.getRPIGenerationCode())")
 # set default to RPi 1 interface config file
 INTERFACE_FILE="rpi1.cfg"
 if [ "$RPI_VERSION" == "RPI2" ] || [ "$RPI_VERSION" == "RPI3" ] || [ "$RPI_VERSION" == "RPI3B+" ]; then

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -410,11 +410,16 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
     def orbit(self, degrees, radius_cm=0, blocking=True):
         """
-        Control the GoPiGo so it will orbit around an object
-
+        Control the GoPiGo so it will orbit around an object.  
+        
         :param int degrees: Degrees to steer. **360** for full rotation. Negative for left turn.
         :param int radius_cm: Radius in `cm` of the circle to drive. Default is **0** (turn in place).
         :param boolean blocking = True: Set it as a blocking or non-blocking method.
+
+        .. important:: 
+           Note that while in non-blocking mode the speed cannot be changed before the end of the orbit as it would negate all orbit calculations. 
+           After a non-blocking call, :py:meth:`~easygopigo3.EasyGoPiGo3.set_speed` has to be called before any other movement.
+
         """
         speed = self.get_speed()
         radius = radius_cm * 10
@@ -476,8 +481,9 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
                     StartPositionRight + (right_target * direction)) is False:
                 time.sleep(0.1)
         
-        # reset to original speed
-        self.set_speed(speed)
+            # reset to original speed once done
+            # if non-blocking, then the user is responsible in resetting the speed
+            self.set_speed(speed)
         
         return
 

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -449,13 +449,14 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         
         # determine driving direction from the speed
         direction = 1
+        speed_with_direction = speed
         if speed < 0:
             direction = -1
-            speed = -speed
+            speed_with_direction = -speed
         
         # calculate the motor speed for each motor
-        fast_speed = speed
-        slow_speed = abs((speed * slow_target) / fast_target)
+        fast_speed = speed_with_direction
+        slow_speed = abs((speed_with_direction * slow_target) / fast_target)
         
         # set the motor speeds
         self.set_motor_limits(MOTOR_FAST, dps = fast_speed)
@@ -474,6 +475,9 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
                     StartPositionLeft + (left_target * direction),
                     StartPositionRight + (right_target * direction)) is False:
                 time.sleep(0.1)
+        
+        # reset to original speed
+        self.set_speed(speed)
         
         return
 


### PR DESCRIPTION
No Python2 on DexterOS.
I checked that python and python3 are symlinks to the same file. So specifying python3 should be ok.
@RobertLucian  can you confirm?