### PR TITLE
wheel_base_width as instantiation parameter

### DIFF
--- a/Software/Python/gopigo3.py
+++ b/Software/Python/gopigo3.py
@@ -202,15 +202,17 @@ class GoPiGo3(object):
     GROVE_LOW  = 0
     GROVE_HIGH = 1
 
-    def __init__(self, addr = 8, detect = True):
+    def __init__(self, addr=8, detect=True, wheel_base_width=117):
         """
         Do any necessary configuration, and optionally detect the GoPiGo3
+        
+        :param int addr: Optionally set the SPI address to something other than 8
+        :param bool detect: Optionally disable the detection of the GoPiGo3 hardware. This can be used for debugging and testing when the GoPiGo3 would otherwise not pass the detection tests
+        :param int wheel_base_width: adjust the distance between the two wheels (center to center) in order to gain better out from turn_degrees() and other methods
 
-        * Optionally set the SPI address to something other than 8
-        * Optionally disable the detection of the GoPiGo3 hardware. This can be used for debugging
-          and testing when the GoPiGo3 would otherwise not pass the detection tests.
         """
         
+        WHEEL_BASE_WIDTH = wheel_base_width
         # Make sure the SPI lines are configured for mode ALT0 so that the hardware SPI controller can use them
         subprocess.call('gpio mode 12 ALT0', shell=True)
         subprocess.call('gpio mode 13 ALT0', shell=True)


### PR DESCRIPTION
For discussion:
We've had a few complaints lately that the 90 degrees turn isn't a real 90 degrees. Yesterday I picked a GPG3 that wasn't giving me a nice right angle turn. Turns out this particular one has a wheel base of 119mm and not 117. Fixing that got the right angle turn to behave. 
However, it implies re-installing the library in order to bring such a change. And that means each update would lose this change.

By exposing wheel_base_width in the instantiation call, we offer an extra choice to the user. The wheel base can be set programmatically. 
The previous method of editing gopigo3.py is still available.

Other possibility to explore, if we want: save the wheel base width somewhere on the SD card so that the user doesn't have to remember to pass it in the instantiation call, and it won't go away when the user does an update.  Worth it, or not? 