### PR TITLE
Feature/antenna led for wifi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,14 +94,8 @@ ENV/
 .ropeproject
 
 # End of https://www.gitignore.io/api/python
-sftp-config.json
-sftp-config-alt.json
-sftp-config-alt2.json
-sftp-config-alt3.json
-sftp-config-alt4.json
-sftp-config-alt5.json
-sftp-config-alt6.json
+sftp-config*
 .json
 
 .ftpconfig
-.vscode/sftp.json
+.vscode/*

--- a/Install/antenna_wifi.service
+++ b/Install/antenna_wifi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Antenna Wifi Indicator
+
+[Service]
+Type=idle
+User=pi
+WorkingDirectory=/home/pi
+ExecStart=/bin/bash /home/pi/Dexter/GoPiGo3/Install/antenna_wifi.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/Install/antenna_wifi.sh
+++ b/Install/antenna_wifi.sh
@@ -1,0 +1,16 @@
+# 1 Detect if we are on a GoPiGo3
+# 2 Detect if we have Wifi connection
+# 3 Throw a yellow-orangey LED or turn it off
+
+
+# If detected_robot exists and it contains GoPiGo3, or 
+# if it doesn't exist at all on standalone Raspbian
+if [ -f "/home/pi/Dexter/detected_robot.txt" ] && grep -q GoPiGo3 /home/pi/Dexter/detected_robot.txt  || [  ! -f "/home/pi/Dexter/detected_robot.txt" ]
+then
+    if iwgetid --scheme
+    then
+        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,5,5,0)"
+    else
+        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,0,0,0)"
+    fi
+fi

--- a/Install/antenna_wifi.sh
+++ b/Install/antenna_wifi.sh
@@ -9,7 +9,7 @@ if [ -f "/home/pi/Dexter/detected_robot.txt" ] && grep -q GoPiGo3 /home/pi/Dexte
 then
     if iwgetid --scheme
     then
-        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,5,5,0)"
+        python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,15,3,0)"
     else
         python -c "import gopigo3;GPG=gopigo3.GoPiGo3();GPG.set_led(GPG.LED_WIFI,0,0,0)"
     fi

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -77,6 +77,14 @@ enable_spi() {
 
 }
 
+install_wifi_antenna() {
+    sudo cp -f $GOPIGO3_DIR/Install/antenna_wifi.service /etc/systemd/system/antenna_wifi.service
+    sudo chown root:root /etc/systemd/system/antenna_wifi.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable antenna_wifi.service
+    sudo systemctl start antenna_wifi.service
+}
+
 # Enable GoPiGo3 Power Services in Systemd
 # Make sure the gopigo3_power.py program will run at boot
 
@@ -93,3 +101,4 @@ check_root_user
 install_dependencies
 install_wiringpi
 enable_spi
+install_wifi_antenna


### PR DESCRIPTION
When in Raspbian or Raspbian for Robots, once the GoPiGo3 is connected to a WiFi access point, the antenna LED will be a pale yellow, very different from the green and blue for DexterOS. 
This gives the user a nice feedback that the robot is connected to Wifi and removes the guessing game. 

This means a new service is installed: _antenna_wifi.service_  which runs every 10 seconds, for less than 0.2 sec on average.  A user can always choose to disable this service with the standard
sudo systemctl disable antenna_wifi.service