### PR TITLE
allow distance sensor to be on any port

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -1017,11 +1017,11 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
 
         Initialises a :py:class:`~di_sensors.easy_distance_sensor.EasyDistanceSensor` object and then returns it.
 
-        :param str port = "I2C": The only option for this parameter is ``"I2C"``. The parameter has ``"I2C"`` as a default value.
+        :param str port = "I2C": The options for this parameter are ``"I2C"`` by default, ``"AD1"``, or ``"AD2"``.
         :returns: An instance of the :py:class:`~di_sensors.easy_distance_sensor.EasyDistanceSensor` class and with the port set to ``port``'s value.
         :raises ImportError: When the :py:mod:`di_sensors` module can't be found. Check the `DI-Sensors`_ documentation on how to install the libraries.
 
-        The ``"I2C"`` ports are mapped to the following :ref:`hardware-ports-section`.
+        The ports are mapped to the following :ref:`hardware-ports-section`.
 
         The ``use_mutex`` parameter of the :py:meth:`~easygopigo3.EasyGoPiGo3.__init__` constructor is passed down to the constructor of :py:class:`~di_sensors.easy_distance_sensor.EasyDistanceSensor` class.
 
@@ -1037,7 +1037,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         if di_sensors_available is False:
             raise ImportError("di_sensors library not available")
 
-        return easy_distance_sensor.EasyDistanceSensor(use_mutex=self.use_mutex)
+        return easy_distance_sensor.EasyDistanceSensor(port=port, use_mutex=self.use_mutex)
 
 
     def init_dht_sensor(self, sensor_type = 0):


### PR DESCRIPTION
I thought I had done this already, but it seems not. 
Needed for Python curriculum. 