### PR TITLE
Fix a runtime error

### DIFF
--- a/Software/Scratch/GoPiGo3Scratch.py
+++ b/Software/Scratch/GoPiGo3Scratch.py
@@ -1071,7 +1071,7 @@ if __name__ == '__main__':
             logger.info("GoPiGo3 Scratch: Disconnected from Scratch")
             break
         except (scratch.scratch.ScratchConnectionError, NameError) as e:
-            logger.info("exception error: ", e)
+            logger.info("exception error: {}".format(e))
             while True:
                 logger.info("GoPiGo3 Scratch: Scratch connection error, Retrying")
                 time.sleep(5)


### PR DESCRIPTION
Small error showing up if user closes Scratch directly.
Error introduced when I moved all print statements to logger statements. 