### PR TITLE
allow RPi4 to flash firmware

### DIFF
--- a/Firmware/gopigo3_flash_firmware.sh
+++ b/Firmware/gopigo3_flash_firmware.sh
@@ -10,6 +10,9 @@ if [ "$RPI_VERSION" == "RPI1" ] || [ "$RPI_VERSION" == "RPI0" ]; then
 elif [ "$RPI_VERSION" == "RPI2" ] || [ "$RPI_VERSION" == "RPI3" ] || [ "$RPI_VERSION" == "RPI3B+" ] || [ "$RPI_VERSION" == "RPI3A+" ]; then
     # use rpi2 interface config file
     INTERFACE_FILE="rpi2.cfg"
+elif [ "$RPI_VERSION" == "RPI4" ]; then
+    # use rpi4 interface config file
+    INTERFACE_FILE="rpi4.cfg"
 fi
 
 if [ "$INTERFACE_FILE" == "none" ]; then


### PR DESCRIPTION
This PR will only work if openOCD is also updated. The scripts are expected to keep them in sync.