### PR TITLE
Optimize notebook

### DIFF
--- a/Projects/Connectome/Connectome.ipynb
+++ b/Projects/Connectome/Connectome.ipynb
@@ -1,28 +1,54 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GoPiGo Connectome\n",
+    "Written by Timothy Busbice, Gabriel Garrett, Geoffrey Churchill (c) 2014, in Python 2.7\n",
+    "Modified by John Cole and Nicole Parrot in 2019 to work with Python 3.x and the GoPiGo3\n",
+    "\n",
+    "## The GoPiGo Connectome uses a Postsynaptic dictionary based on the C Elegans Connectome Model\n",
+    "This application can be run on the Raspberry Pi GoPiGo robot with a distance sensor that represents Nose Touch when activated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__define constants that are relevant to the robot__"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# GoPiGo Connectome\n",
-    "# Written by Timothy Busbice, Gabriel Garrett, Geoffrey Churchill (c) 2014, in Python 2.7\n",
-    "# Modified by John Cole in 2019 to work with Python 3.x and the GoPiGo3\n",
-    "# The GoPiGo Connectome uses a Postsynaptic dictionary based on the C Elegans Connectome Model\n",
-    "# This application can be ran on the Raspberry Pi GoPiGo robot with a Sonar that represents Nose Touch when activated\n",
-    "# To run standalone without a GoPiGo robot, simply comment out the sections with Start and End comments\n",
-    "## Start Comment\n",
     "from easygopigo3 import EasyGoPiGo3 # importing the EasyGoPiGo3 class\n",
-    "gpg = EasyGoPiGo3() # instantiating a EasyGoPiGo3 object\n",
-    "gpg.reset_all()   # Unconfigure the sensors, disable the motors, and restore the LED to the control of the GoPiGo3 firmware.\n",
-    "gpg_speed_factor = 2 # the GPG3 has a different speed scale than the GPG2\n",
-    "my_distance_sensor = gpg.init_distance_sensor()\n",
-    "food_color = (10,10,40)\n",
-    "obstacle_color = (40,10,10)\n",
-    "## End Comment\n",
     "import time\n",
     "\n",
+    "gpg = EasyGoPiGo3() # instantiating a EasyGoPiGo3 object\n",
+    "gpg_speed_factor = 2 # the GPG3 has a different speed scale than the GPG2\n",
+    "my_distance_sensor = gpg.init_distance_sensor()\n",
+    "food_color = (5,5,80)\n",
+    "obstacle_color = (40,10,10)\n",
+    "awake_color = (5,5,5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__define the connectome variables__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# The postsynaptic dictionary contains the accumulated weighted values as the\n",
     "# connectome is executed\n",
     "postsynaptic = {}\n",
@@ -48,13 +74,33 @@
     "musDleft = ['MDL07', 'MDL08', 'MDL09', 'MDL10', 'MDL11', 'MDL12', 'MDL13', 'MDL14', 'MDL15', 'MDL16', 'MDL17', 'MDL18', 'MDL19', 'MDL20', 'MDL21', 'MDL22', 'MDL23']\n",
     "musVleft = ['MVL07', 'MVL08', 'MVL09', 'MVL10', 'MVL11', 'MVL12', 'MVL13', 'MVL14', 'MVL15', 'MVL16', 'MVL17', 'MVL18', 'MVL19', 'MVL20', 'MVL21', 'MVL22', 'MVL23']\n",
     "musDright = ['MDR07', 'MDR08', 'MDR09', 'MDR10', 'MDR11', 'MDR12', 'MDR13', 'MDR14', 'MDR15', 'MDR16', 'MDR17', 'MDR18', 'MDR19', 'MDR20', 'MDL21', 'MDR22', 'MDR23']\n",
-    "musVright = ['MVR07', 'MVR08', 'MVR09', 'MVR10', 'MVR11', 'MVR12', 'MVR13', 'MVR14', 'MVR15', 'MVR16', 'MVR17', 'MVR18', 'MVR19', 'MVR20', 'MVL21', 'MVR22', 'MVR23']\n",
+    "musVright = ['MVR07', 'MVR08', 'MVR09', 'MVR10', 'MVR11', 'MVR12', 'MVR13', 'MVR14', 'MVR15', 'MVR16', 'MVR17', 'MVR18', 'MVR19', 'MVR20', 'MVL21', 'MVR22', 'MVR23']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## This is the full C Elegans Connectome as expressed in the form of the Presynatptic neurite and the postsynaptic neurites\n",
     "\n",
-    "# This is the full C Elegans Connectome as expresed in the form of the Presynatptic\n",
-    "# neurite and the postsynaptic neurites\n",
-    "# postsynaptic['ADAR'][nextState] = (2 + postsynaptic['ADAR'][thisState])\n",
-    "# arr=postsynaptic['AIBR'] potential optimization\n",
-    "\n",
+    "There are many many rows so they may have been collapsed (you will see ellipsis where they are collapsed).  \n",
+    "* To expand a collapsed row, click on the ellipsis.\n",
+    "* To collapse an expanded row, click on the vertical blue line to the left of that row.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__ADA__ to __ADE__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def ADAL():\n",
     "        postsynaptic['ADAR'][nextState] = 2 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['ADFL'][nextState] = 1 + postsynaptic['ADFL'][thisState]\n",
@@ -94,7 +140,7 @@
     "        postsynaptic['RIPR'][nextState] = 1 + postsynaptic['RIPR'][thisState]\n",
     "        postsynaptic['RIVR'][nextState] = 1 + postsynaptic['RIVR'][thisState]\n",
     "        postsynaptic['SMDVL'][nextState] = 2 + postsynaptic['SMDVL'][thisState]\n",
-    "\n",
+    "        \n",
     "def ADEL():\n",
     "        postsynaptic['ADAL'][nextState] = 1 + postsynaptic['ADAL'][thisState]\n",
     "        postsynaptic['ADER'][nextState] = 1 + postsynaptic['ADER'][thisState]\n",
@@ -125,7 +171,7 @@
     "        postsynaptic['SIBDR'][nextState] = 1 + postsynaptic['SIBDR'][thisState]\n",
     "        postsynaptic['SMBDR'][nextState] = 1 + postsynaptic['SMBDR'][thisState]\n",
     "        postsynaptic['URBL'][nextState] = 1 + postsynaptic['URBL'][thisState]\n",
-    "\n",
+    "        \n",
     "def ADER():\n",
     "        postsynaptic['ADAR'][nextState] = 1 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['ADEL'][nextState] = 2 + postsynaptic['ADEL'][thisState]\n",
@@ -147,7 +193,22 @@
     "        postsynaptic['RIH'][nextState] = 1 + postsynaptic['RIH'][thisState]\n",
     "        postsynaptic['RMDR'][nextState] = 2 + postsynaptic['RMDR'][thisState]\n",
     "        postsynaptic['SAAVR'][nextState] = 1 + postsynaptic['SAAVR'][thisState]\n",
-    "\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__ADF__ to __ADL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def ADFL():\n",
     "        postsynaptic['ADAL'][nextState] = 2 + postsynaptic['ADAL'][thisState]\n",
     "        postsynaptic['AIZL'][nextState] = 12 + postsynaptic['AIZL'][thisState]\n",
@@ -157,7 +218,7 @@
     "        postsynaptic['RIGL'][nextState] = 1 + postsynaptic['RIGL'][thisState]\n",
     "        postsynaptic['RIR'][nextState] = 2 + postsynaptic['RIR'][thisState]\n",
     "        postsynaptic['SMBVL'][nextState] = 2 + postsynaptic['SMBVL'][thisState]\n",
-    "\n",
+    "        \n",
     "def ADFR():\n",
     "        postsynaptic['ADAR'][nextState] = 2 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['AIAR'][nextState] = 1 + postsynaptic['AIAR'][thisState]\n",
@@ -173,7 +234,7 @@
     "        postsynaptic['SMBDR'][nextState] = 1 + postsynaptic['SMBDR'][thisState]\n",
     "        postsynaptic['SMBVR'][nextState] = 2 + postsynaptic['SMBVR'][thisState]\n",
     "        postsynaptic['URXR'][nextState] = 1 + postsynaptic['URXR'][thisState]\n",
-    "\n",
+    "        \n",
     "def ADLL():\n",
     "        postsynaptic['ADLR'][nextState] = 1 + postsynaptic['ADLR'][thisState]\n",
     "        postsynaptic['AIAL'][nextState] = 6 + postsynaptic['AIAL'][thisState]\n",
@@ -194,7 +255,7 @@
     "        postsynaptic['OLQVL'][nextState] = 2 + postsynaptic['OLQVL'][thisState]\n",
     "        postsynaptic['RIPL'][nextState] = 1 + postsynaptic['RIPL'][thisState]\n",
     "        postsynaptic['RMGL'][nextState] = 1 + postsynaptic['RMGL'][thisState]\n",
-    "\n",
+    "        \n",
     "def ADLR():\n",
     "        postsynaptic['ADLL'][nextState] = 1 + postsynaptic['ADLL'][thisState]\n",
     "        postsynaptic['AIAR'][nextState] = 10 + postsynaptic['AIAR'][thisState]\n",
@@ -211,20 +272,48 @@
     "        postsynaptic['OLLR'][nextState] = 1 + postsynaptic['OLLR'][thisState]\n",
     "        postsynaptic['PVCL'][nextState] = 1 + postsynaptic['PVCL'][thisState]\n",
     "        postsynaptic['RICL'][nextState] = 1 + postsynaptic['RICL'][thisState]\n",
-    "        postsynaptic['RICR'][nextState] = 1 + postsynaptic['RICR'][thisState]\n",
-    "\n",
+    "        postsynaptic['RICR'][nextState] = 1 + postsynaptic['RICR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AF__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AFDL():\n",
     "        postsynaptic['AFDR'][nextState] = 1 + postsynaptic['AFDR'][thisState]\n",
     "        postsynaptic['AIBL'][nextState] = 1 + postsynaptic['AIBL'][thisState]\n",
     "        postsynaptic['AINR'][nextState] = 1 + postsynaptic['AINR'][thisState]\n",
     "        postsynaptic['AIYL'][nextState] = 7 + postsynaptic['AIYL'][thisState]\n",
-    "\n",
+    "        \n",
     "def AFDR():\n",
     "        postsynaptic['AFDL'][nextState] = 1 + postsynaptic['AFDL'][thisState]\n",
     "        postsynaptic['AIBR'][nextState] = 1 + postsynaptic['AIBR'][thisState]\n",
     "        postsynaptic['AIYR'][nextState] = 13 + postsynaptic['AIYR'][thisState]\n",
-    "        postsynaptic['ASER'][nextState] = 1 + postsynaptic['ASER'][thisState]\n",
-    "\n",
+    "        postsynaptic['ASER'][nextState] = 1 + postsynaptic['ASER'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AIA__, __AIB__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AIAL():\n",
     "        postsynaptic['ADAL'][nextState] = 1 + postsynaptic['ADAL'][thisState]\n",
     "        postsynaptic['AIAR'][nextState] = 1 + postsynaptic['AIAR'][thisState]\n",
@@ -241,7 +330,7 @@
     "        postsynaptic['HSNL'][nextState] = 1 + postsynaptic['HSNL'][thisState]\n",
     "        postsynaptic['RIFL'][nextState] = 1 + postsynaptic['RIFL'][thisState]\n",
     "        postsynaptic['RMGL'][nextState] = 1 + postsynaptic['RMGL'][thisState]\n",
-    "\n",
+    "        \n",
     "def AIAR():\n",
     "        postsynaptic['ADAR'][nextState] = 1 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['ADFR'][nextState] = 1 + postsynaptic['ADFR'][thisState]\n",
@@ -256,7 +345,7 @@
     "        postsynaptic['AWCL'][nextState] = 1 + postsynaptic['AWCL'][thisState]\n",
     "        postsynaptic['AWCR'][nextState] = 3 + postsynaptic['AWCR'][thisState]\n",
     "        postsynaptic['RIFR'][nextState] = 2 + postsynaptic['RIFR'][thisState]\n",
-    "\n",
+    "        \n",
     "def AIBL():\n",
     "        postsynaptic['AFDL'][nextState] = 1 + postsynaptic['AFDL'][thisState]\n",
     "        postsynaptic['AIYL'][nextState] = 1 + postsynaptic['AIYL'][thisState]\n",
@@ -277,7 +366,7 @@
     "        postsynaptic['SAADL'][nextState] = 2 + postsynaptic['SAADL'][thisState]\n",
     "        postsynaptic['SAADR'][nextState] = 2 + postsynaptic['SAADR'][thisState]\n",
     "        postsynaptic['SMDDR'][nextState] = 4 + postsynaptic['SMDDR'][thisState]\n",
-    "\n",
+    "        \n",
     "def AIBR():\n",
     "        postsynaptic['AFDR'][nextState] = 1 + postsynaptic['AFDR'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 1 + postsynaptic['AVAR'][thisState]\n",
@@ -297,8 +386,22 @@
     "        postsynaptic['SAADL'][nextState] = 1 + postsynaptic['SAADL'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 3 + postsynaptic['SMDDL'][thisState]\n",
     "        postsynaptic['SMDVL'][nextState] = 1 + postsynaptic['SMDVL'][thisState]\n",
-    "        postsynaptic['VB1'][nextState] = 3 + postsynaptic['VB1'][thisState]\n",
-    "\n",
+    "        postsynaptic['VB1'][nextState] = 3 + postsynaptic['VB1'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AIM__, __AIN__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AIML():\n",
     "        postsynaptic['AIAL'][nextState] = 5 + postsynaptic['AIAL'][thisState]\n",
     "        postsynaptic['ALML'][nextState] = 1 + postsynaptic['ALML'][thisState]\n",
@@ -357,8 +460,22 @@
     "        postsynaptic['AUAR'][nextState] = 1 + postsynaptic['AUAR'][thisState]\n",
     "        postsynaptic['BAGR'][nextState] = 3 + postsynaptic['BAGR'][thisState]\n",
     "        postsynaptic['RIBL'][nextState] = 2 + postsynaptic['RIBL'][thisState]\n",
-    "        postsynaptic['RID'][nextState] = 1 + postsynaptic['RID'][thisState]\n",
-    "\n",
+    "        postsynaptic['RID'][nextState] = 1 + postsynaptic['RID'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AIY__, __AIZ__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AIYL():\n",
     "        postsynaptic['AIYR'][nextState] = 1 + postsynaptic['AIYR'][thisState]\n",
     "        postsynaptic['AIZL'][nextState] = 13 + postsynaptic['AIZL'][thisState]\n",
@@ -412,8 +529,22 @@
     "        postsynaptic['RIMR'][nextState] = 4 + postsynaptic['RIMR'][thisState]\n",
     "        postsynaptic['SMBDR'][nextState] = 5 + postsynaptic['SMBDR'][thisState]\n",
     "        postsynaptic['SMBVR'][nextState] = 3 + postsynaptic['SMBVR'][thisState]\n",
-    "        postsynaptic['SMDDR'][nextState] = 1 + postsynaptic['SMDDR'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDDR'][nextState] = 1 + postsynaptic['SMDDR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def ALA():\n",
     "        postsynaptic['ADEL'][nextState] = 1 + postsynaptic['ADEL'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 1 + postsynaptic['AVAL'][thisState]\n",
@@ -458,7 +589,22 @@
     "        postsynaptic['SMBDL'][nextState] = 2 + postsynaptic['SMBDL'][thisState]\n",
     "        postsynaptic['SMDDR'][nextState] = 1 + postsynaptic['SMDDR'][thisState]\n",
     "        postsynaptic['SMDVL'][nextState] = 1 + postsynaptic['SMDVL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AQ__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AQR():\n",
     "        postsynaptic['AVAL'][nextState] = 1 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 3 + postsynaptic['AVAR'][thisState]\n",
@@ -481,7 +627,22 @@
     "        postsynaptic['RIGL'][nextState] = 2 + postsynaptic['RIGL'][thisState]\n",
     "        postsynaptic['RIGR'][nextState] = 1 + postsynaptic['RIGR'][thisState]\n",
     "        postsynaptic['URXL'][nextState] = 1 + postsynaptic['URXL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AS1__ to __AS6__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AS1():\n",
     "        postsynaptic['AVAL'][nextState] = 3 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 2 + postsynaptic['AVAR'][thisState]\n",
@@ -549,8 +710,22 @@
     "        postsynaptic['MDR13'][nextState] = 3 + postsynaptic['MDR13'][thisState]\n",
     "        postsynaptic['MDR14'][nextState] = 2 + postsynaptic['MDR14'][thisState]\n",
     "        postsynaptic['VA8'][nextState] = 1 + postsynaptic['VA8'][thisState]\n",
-    "        postsynaptic['VD6'][nextState] = 13 + postsynaptic['VD6'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD6'][nextState] = 13 + postsynaptic['VD6'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AS7__ to __AS11__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AS7():\n",
     "        postsynaptic['AVAL'][nextState] = 6 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 5 + postsynaptic['AVAR'][thisState]\n",
@@ -585,7 +760,7 @@
     "        postsynaptic['MDL20'][nextState] = 2 + postsynaptic['MDL20'][thisState]\n",
     "        postsynaptic['MDR19'][nextState] = 3 + postsynaptic['MDR19'][thisState]\n",
     "        postsynaptic['MDR20'][nextState] = 2 + postsynaptic['MDR20'][thisState]\n",
-    "\n",
+    "        \n",
     "def AS11():\n",
     "        postsynaptic['MDL21'][nextState] = 1 + postsynaptic['MDL21'][thisState]\n",
     "        postsynaptic['MDL22'][nextState] = 1 + postsynaptic['MDL22'][thisState]\n",
@@ -598,8 +773,22 @@
     "        postsynaptic['PDA'][nextState] = 1 + postsynaptic['PDA'][thisState]\n",
     "        postsynaptic['PDB'][nextState] = 1 + postsynaptic['PDB'][thisState]\n",
     "        postsynaptic['PDB'][nextState] = 2 + postsynaptic['PDB'][thisState]\n",
-    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__ASE__ to __ASH__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def ASEL():\n",
     "        postsynaptic['ADFR'][nextState] = 1 + postsynaptic['ADFR'][thisState]\n",
     "        postsynaptic['AIAL'][nextState] = 3 + postsynaptic['AIAL'][thisState]\n",
@@ -674,8 +863,22 @@
     "        postsynaptic['RIAR'][nextState] = 2 + postsynaptic['RIAR'][thisState]\n",
     "        postsynaptic['RICR'][nextState] = 2 + postsynaptic['RICR'][thisState]\n",
     "        postsynaptic['RMGR'][nextState] = 2 + postsynaptic['RMGR'][thisState]\n",
-    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]\n",
-    "\n",
+    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__ASI__ to __ASK__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def ASIL():\n",
     "        postsynaptic['AIAL'][nextState] = 2 + postsynaptic['AIAL'][thisState]\n",
     "        postsynaptic['AIBL'][nextState] = 1 + postsynaptic['AIBL'][thisState]\n",
@@ -699,6 +902,7 @@
     "        postsynaptic['AWCL'][nextState] = 1 + postsynaptic['AWCL'][thisState]\n",
     "        postsynaptic['AWCR'][nextState] = 1 + postsynaptic['AWCR'][thisState]\n",
     "\n",
+    "\n",
     "def ASJL():\n",
     "        postsynaptic['ASJR'][nextState] = 1 + postsynaptic['ASJR'][thisState]\n",
     "        postsynaptic['ASKL'][nextState] = 4 + postsynaptic['ASKL'][thisState]\n",
@@ -712,6 +916,7 @@
     "        postsynaptic['HSNR'][nextState] = 1 + postsynaptic['HSNR'][thisState]\n",
     "        postsynaptic['PVQR'][nextState] = 13 + postsynaptic['PVQR'][thisState]\n",
     "\n",
+    "\n",
     "def ASKL():\n",
     "        postsynaptic['AIAL'][nextState] = 11 + postsynaptic['AIAL'][thisState]\n",
     "        postsynaptic['AIBL'][nextState] = 2 + postsynaptic['AIBL'][thisState]\n",
@@ -719,6 +924,7 @@
     "        postsynaptic['ASKR'][nextState] = 1 + postsynaptic['ASKR'][thisState]\n",
     "        postsynaptic['PVQL'][nextState] = 5 + postsynaptic['PVQL'][thisState]\n",
     "        postsynaptic['RMGL'][nextState] = 1 + postsynaptic['RMGL'][thisState]\n",
+    "\n",
     "\n",
     "def ASKR():\n",
     "        postsynaptic['AIAR'][nextState] = 11 + postsynaptic['AIAR'][thisState]\n",
@@ -729,8 +935,22 @@
     "        postsynaptic['CEPVR'][nextState] = 1 + postsynaptic['CEPVR'][thisState]\n",
     "        postsynaptic['PVQR'][nextState] = 4 + postsynaptic['PVQR'][thisState]\n",
     "        postsynaptic['RIFR'][nextState] = 1 + postsynaptic['RIFR'][thisState]\n",
-    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]\n",
-    "\n",
+    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AU__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AUAL():\n",
     "        postsynaptic['AINR'][nextState] = 1 + postsynaptic['AINR'][thisState]\n",
     "        postsynaptic['AUAR'][nextState] = 1 + postsynaptic['AUAR'][thisState]\n",
@@ -751,7 +971,22 @@
     "        postsynaptic['RIAR'][nextState] = 6 + postsynaptic['RIAR'][thisState]\n",
     "        postsynaptic['RIBR'][nextState] = 13 + postsynaptic['RIBR'][thisState]\n",
     "        postsynaptic['URXR'][nextState] = 1 + postsynaptic['URXR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVAL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVAL():\n",
     "        postsynaptic['AS1'][nextState] = 3 + postsynaptic['AS1'][thisState]\n",
     "        postsynaptic['AS10'][nextState] = 3 + postsynaptic['AS10'][thisState]\n",
@@ -803,8 +1038,22 @@
     "        postsynaptic['VA7'][nextState] = 2 + postsynaptic['VA7'][thisState]\n",
     "        postsynaptic['VA8'][nextState] = 19 + postsynaptic['VA8'][thisState]\n",
     "        postsynaptic['VA9'][nextState] = 8 + postsynaptic['VA9'][thisState]\n",
-    "        postsynaptic['VB9'][nextState] = 5 + postsynaptic['VB9'][thisState]\n",
-    "\n",
+    "        postsynaptic['VB9'][nextState] = 5 + postsynaptic['VB9'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVAR__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVAR():\n",
     "        postsynaptic['ADER'][nextState] = 1 + postsynaptic['ADER'][thisState]\n",
     "        postsynaptic['AS1'][nextState] = 3 + postsynaptic['AS1'][thisState]\n",
@@ -861,8 +1110,22 @@
     "        postsynaptic['VA7'][nextState] = 4 + postsynaptic['VA7'][thisState]\n",
     "        postsynaptic['VA8'][nextState] = 16 + postsynaptic['VA8'][thisState]\n",
     "        postsynaptic['VB9'][nextState] = 10 + postsynaptic['VB9'][thisState]\n",
-    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVB__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVBL():\n",
     "        postsynaptic['AQR'][nextState] = 1 + postsynaptic['AQR'][thisState]\n",
     "        postsynaptic['AS10'][nextState] = 1 + postsynaptic['AS10'][thisState]\n",
@@ -947,8 +1210,22 @@
     "        postsynaptic['VB8'][nextState] = 3 + postsynaptic['VB8'][thisState]\n",
     "        postsynaptic['VB9'][nextState] = 6 + postsynaptic['VB9'][thisState]\n",
     "        postsynaptic['VD10'][nextState] = 1 + postsynaptic['VD10'][thisState]\n",
-    "        postsynaptic['VD3'][nextState] = 1 + postsynaptic['VD3'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD3'][nextState] = 1 + postsynaptic['VD3'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVDL():\n",
     "        postsynaptic['ADAR'][nextState] = 2 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['AS1'][nextState] = 1 + postsynaptic['AS1'][thisState]\n",
@@ -1002,8 +1279,22 @@
     "        postsynaptic['VA11'][nextState] = 1 + postsynaptic['VA11'][thisState]\n",
     "        postsynaptic['VA2'][nextState] = 1 + postsynaptic['VA2'][thisState]\n",
     "        postsynaptic['VA3'][nextState] = 2 + postsynaptic['VA3'][thisState]\n",
-    "        postsynaptic['VA6'][nextState] = 1 + postsynaptic['VA6'][thisState]\n",
-    "\n",
+    "        postsynaptic['VA6'][nextState] = 1 + postsynaptic['VA6'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVE__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVEL():\n",
     "        postsynaptic['AS1'][nextState] = 1 + postsynaptic['AS1'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 12 + postsynaptic['AVAL'][thisState]\n",
@@ -1051,8 +1342,22 @@
     "        postsynaptic['VA2'][nextState] = 1 + postsynaptic['VA2'][thisState]\n",
     "        postsynaptic['VA3'][nextState] = 2 + postsynaptic['VA3'][thisState]\n",
     "        postsynaptic['VA4'][nextState] = 1 + postsynaptic['VA4'][thisState]\n",
-    "        postsynaptic['VA5'][nextState] = 1 + postsynaptic['VA5'][thisState]\n",
-    "\n",
+    "        postsynaptic['VA5'][nextState] = 1 + postsynaptic['VA5'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVF__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVFL():\n",
     "        postsynaptic['AVBL'][nextState] = 1 + postsynaptic['AVBL'][thisState]\n",
     "        postsynaptic['AVBR'][nextState] = 2 + postsynaptic['AVBR'][thisState]\n",
@@ -1087,8 +1392,22 @@
     "        postsynaptic['MVR14'][nextState] = 2 + postsynaptic['MVR14'][thisState]\n",
     "        postsynaptic['PVQL'][nextState] = 1 + postsynaptic['PVQL'][thisState]\n",
     "        postsynaptic['VC4'][nextState] = 1 + postsynaptic['VC4'][thisState]\n",
-    "        postsynaptic['VD11'][nextState] = 1 + postsynaptic['VD11'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD11'][nextState] = 1 + postsynaptic['VD11'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVG__, __AVH__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVG():\n",
     "        postsynaptic['AVAR'][nextState] = 3 + postsynaptic['AVAR'][thisState]\n",
     "        postsynaptic['AVBL'][nextState] = 1 + postsynaptic['AVBL'][thisState]\n",
@@ -1147,8 +1466,22 @@
     "        postsynaptic['RIGL'][nextState] = 1 + postsynaptic['RIGL'][thisState]\n",
     "        postsynaptic['RIR'][nextState] = 4 + postsynaptic['RIR'][thisState]\n",
     "        postsynaptic['SMBDL'][nextState] = 1 + postsynaptic['SMBDL'][thisState]\n",
-    "        postsynaptic['SMBVL'][nextState] = 1 + postsynaptic['SMBVL'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMBVL'][nextState] = 1 + postsynaptic['SMBVL'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVJ__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVJL():\n",
     "        postsynaptic['AVAL'][nextState] = 2 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 1 + postsynaptic['AVAR'][thisState]\n",
@@ -1180,8 +1513,22 @@
     "        postsynaptic['PVCL'][nextState] = 3 + postsynaptic['PVCL'][thisState]\n",
     "        postsynaptic['PVCR'][nextState] = 4 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['PVQR'][nextState] = 1 + postsynaptic['PVQR'][thisState]\n",
-    "        postsynaptic['SABVL'][nextState] = 1 + postsynaptic['SABVL'][thisState]\n",
-    "\n",
+    "        postsynaptic['SABVL'][nextState] = 1 + postsynaptic['SABVL'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVK__, __AVL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVKL():\n",
     "        postsynaptic['ADER'][nextState] = 1 + postsynaptic['ADER'][thisState]\n",
     "        postsynaptic['AQR'][nextState] = 2 + postsynaptic['AQR'][thisState]\n",
@@ -1232,7 +1579,7 @@
     "        postsynaptic['SMBVR'][nextState] = 1 + postsynaptic['SMBVR'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 1 + postsynaptic['SMDDL'][thisState]\n",
     "        postsynaptic['SMDDR'][nextState] = 2 + postsynaptic['SMDDR'][thisState]\n",
-    "\n",
+    "        \n",
     "def AVL():\n",
     "        postsynaptic['AVEL'][nextState] = 1 + postsynaptic['AVEL'][thisState]\n",
     "        postsynaptic['AVFR'][nextState] = 1 + postsynaptic['AVFR'][thisState]\n",
@@ -1251,7 +1598,22 @@
     "        postsynaptic['SABVL'][nextState] = 4 + postsynaptic['SABVL'][thisState]\n",
     "        postsynaptic['SABVR'][nextState] = 3 + postsynaptic['SABVR'][thisState]\n",
     "        postsynaptic['VD12'][nextState] = 4 + postsynaptic['VD12'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AVM__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AVM():\n",
     "        postsynaptic['ADER'][nextState] = 1 + postsynaptic['ADER'][thisState]\n",
     "        postsynaptic['ALML'][nextState] = 1 + postsynaptic['ALML'][thisState]\n",
@@ -1269,8 +1631,22 @@
     "        postsynaptic['PVR'][nextState] = 3 + postsynaptic['PVR'][thisState]\n",
     "        postsynaptic['RID'][nextState] = 1 + postsynaptic['RID'][thisState]\n",
     "        postsynaptic['SIBVL'][nextState] = 1 + postsynaptic['SIBVL'][thisState]\n",
-    "        postsynaptic['VA1'][nextState] = 2 + postsynaptic['VA1'][thisState]\n",
-    "\n",
+    "        postsynaptic['VA1'][nextState] = 2 + postsynaptic['VA1'][thisState]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__AW__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def AWAL():\n",
     "        postsynaptic['ADAL'][nextState] = 1 + postsynaptic['ADAL'][thisState]\n",
     "        postsynaptic['AFDL'][nextState] = 5 + postsynaptic['AFDL'][thisState]\n",
@@ -1342,7 +1718,22 @@
     "        postsynaptic['ASEL'][nextState] = 1 + postsynaptic['ASEL'][thisState]\n",
     "        postsynaptic['ASGR'][nextState] = 1 + postsynaptic['ASGR'][thisState]\n",
     "        postsynaptic['AWCL'][nextState] = 5 + postsynaptic['AWCL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__B__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def BAGL():\n",
     "        postsynaptic['AIBL'][nextState] = 1 + postsynaptic['AIBL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 1 + postsynaptic['AVAR'][thisState]\n",
@@ -1390,7 +1781,22 @@
     "        postsynaptic['PVNR'][nextState] = 1 + postsynaptic['PVNR'][thisState]\n",
     "        postsynaptic['SDQL'][nextState] = 1 + postsynaptic['SDQL'][thisState]\n",
     "        postsynaptic['URADR'][nextState] = 1 + postsynaptic['URADR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__CE__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def CEPDL():\n",
     "        postsynaptic['AVER'][nextState] = 5 + postsynaptic['AVER'][thisState]\n",
     "        postsynaptic['IL1DL'][nextState] = 4 + postsynaptic['IL1DL'][thisState]\n",
@@ -1471,7 +1877,22 @@
     "        postsynaptic['RMHR'][nextState] = 2 + postsynaptic['RMHR'][thisState]\n",
     "        postsynaptic['SIAVR'][nextState] = 2 + postsynaptic['SIAVR'][thisState]\n",
     "        postsynaptic['URAVR'][nextState] = 1 + postsynaptic['URAVR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DA1__ to __DA4__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DA1():\n",
     "        postsynaptic['AVAL'][nextState] = 2 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 6 + postsynaptic['AVAR'][thisState]\n",
@@ -1534,8 +1955,22 @@
     "        postsynaptic['MDR14'][nextState] = 5 + postsynaptic['MDR14'][thisState]\n",
     "        postsynaptic['VB6'][nextState] = 1 + postsynaptic['VB6'][thisState]\n",
     "        postsynaptic['VD4'][nextState] = 12 + postsynaptic['VD4'][thisState]\n",
-    "        postsynaptic['VD5'][nextState] = 15 + postsynaptic['VD5'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD5'][nextState] = 15 + postsynaptic['VD5'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DA5__ to __DA9__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DA5():\n",
     "        postsynaptic['AS6'][nextState] = 2 + postsynaptic['AS6'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 1 + postsynaptic['AVAL'][thisState]\n",
@@ -1602,8 +2037,22 @@
     "        postsynaptic['PDA'][nextState] = 1 + postsynaptic['PDA'][thisState]\n",
     "        postsynaptic['PHCL'][nextState] = 1 + postsynaptic['PHCL'][thisState]\n",
     "        postsynaptic['RID'][nextState] = 1 + postsynaptic['RID'][thisState]\n",
-    "        postsynaptic['VD13'][nextState] = 1 + postsynaptic['VD13'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD13'][nextState] = 1 + postsynaptic['VD13'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DB1__ to __DB3__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DB1():\n",
     "        postsynaptic['AIBR'][nextState] = 1 + postsynaptic['AIBR'][thisState]\n",
     "        postsynaptic['AS1'][nextState] = 1 + postsynaptic['AS1'][thisState]\n",
@@ -1665,8 +2114,22 @@
     "        postsynaptic['MDR14'][nextState] = 3 + postsynaptic['MDR14'][thisState]\n",
     "        postsynaptic['VD4'][nextState] = 9 + postsynaptic['VD4'][thisState]\n",
     "        postsynaptic['VD5'][nextState] = 26 + postsynaptic['VD5'][thisState]\n",
-    "        postsynaptic['VD6'][nextState] = 7 + postsynaptic['VD6'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD6'][nextState] = 7 + postsynaptic['VD6'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DB4__ to __DB7__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DB4():\n",
     "        postsynaptic['AVBL'][nextState] = 1 + postsynaptic['AVBL'][thisState]\n",
     "        postsynaptic['AVBR'][nextState] = 1 + postsynaptic['AVBR'][thisState]\n",
@@ -1718,8 +2181,22 @@
     "        postsynaptic['MDR22'][nextState] = 2 + postsynaptic['MDR22'][thisState]\n",
     "        postsynaptic['MDR23'][nextState] = 2 + postsynaptic['MDR23'][thisState]\n",
     "        postsynaptic['MDR24'][nextState] = 2 + postsynaptic['MDR24'][thisState]\n",
-    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD13'][nextState] = 2 + postsynaptic['VD13'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DD1():\n",
     "        postsynaptic['AVBR'][nextState] = 1 + postsynaptic['AVBR'][thisState]\n",
     "        postsynaptic['DD2'][nextState] = 3 + postsynaptic['DD2'][thisState]\n",
@@ -1791,7 +2268,22 @@
     "        postsynaptic['MDR22'][nextState] = -7 + postsynaptic['MDR22'][thisState]\n",
     "        postsynaptic['MDR23'][nextState] = -7 + postsynaptic['MDR23'][thisState]\n",
     "        postsynaptic['MDR24'][nextState] = -7 + postsynaptic['MDR24'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__DV__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def DVA():\n",
     "        postsynaptic['AIZL'][nextState] = 3 + postsynaptic['AIZL'][thisState]\n",
     "        postsynaptic['AQR'][nextState] = 4 + postsynaptic['AQR'][thisState]\n",
@@ -1868,7 +2360,22 @@
     "        postsynaptic['VA9'][nextState] = 1 + postsynaptic['VA9'][thisState]\n",
     "        postsynaptic['VD1'][nextState] = 5 + postsynaptic['VD1'][thisState]\n",
     "        postsynaptic['VD10'][nextState] = 4 + postsynaptic['VD10'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__FL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def FLPL():\n",
     "        postsynaptic['ADEL'][nextState] = 2 + postsynaptic['ADEL'][thisState]\n",
     "        postsynaptic['ADER'][nextState] = 2 + postsynaptic['ADER'][thisState]\n",
@@ -1901,7 +2408,22 @@
     "        postsynaptic['FLPL'][nextState] = 4 + postsynaptic['FLPL'][thisState]\n",
     "        postsynaptic['PVCL'][nextState] = 2 + postsynaptic['PVCL'][thisState]\n",
     "        postsynaptic['VB1'][nextState] = 1 + postsynaptic['VB1'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__HS__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def HSNL():\n",
     "        postsynaptic['AIAL'][nextState] = 1 + postsynaptic['AIAL'][thisState]\n",
     "        postsynaptic['AIZL'][nextState] = 2 + postsynaptic['AIZL'][thisState]\n",
@@ -1950,7 +2472,22 @@
     "        postsynaptic['VC2'][nextState] = 3 + postsynaptic['VC2'][thisState]\n",
     "        postsynaptic['VC3'][nextState] = 1 + postsynaptic['VC3'][thisState]\n",
     "        postsynaptic['VD4'][nextState] = 2 + postsynaptic['VD4'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__I__ followed by a number"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def I1L():\n",
     "        postsynaptic['I1R'][nextState] = 1 + postsynaptic['I1R'][thisState]\n",
     "        postsynaptic['I3'][nextState] = 1 + postsynaptic['I3'][thisState]\n",
@@ -2001,7 +2538,22 @@
     "        postsynaptic['M5'][nextState] = 2 + postsynaptic['M5'][thisState]\n",
     "        postsynaptic['NSML'][nextState] = 2 + postsynaptic['NSML'][thisState]\n",
     "        postsynaptic['NSMR'][nextState] = 2 + postsynaptic['NSMR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__IL1__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def IL1DL():\n",
     "        postsynaptic['IL1DR'][nextState] = 1 + postsynaptic['IL1DR'][thisState]\n",
     "        postsynaptic['IL1L'][nextState] = 1 + postsynaptic['IL1L'][thisState]\n",
@@ -2081,8 +2633,22 @@
     "        postsynaptic['MVR02'][nextState] = 5 + postsynaptic['MVR02'][thisState]\n",
     "        postsynaptic['RIPR'][nextState] = 6 + postsynaptic['RIPR'][thisState]\n",
     "        postsynaptic['RMDDR'][nextState] = 10 + postsynaptic['RMDDR'][thisState]\n",
-    "        postsynaptic['RMER'][nextState] = 1 + postsynaptic['RMER'][thisState]\n",
-    "\n",
+    "        postsynaptic['RMER'][nextState] = 1 + postsynaptic['RMER'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__IL2__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def IL2DL():\n",
     "        postsynaptic['AUAL'][nextState] = 1 + postsynaptic['AUAL'][thisState]\n",
     "        postsynaptic['IL1DL'][nextState] = 7 + postsynaptic['IL1DL'][thisState]\n",
@@ -2157,8 +2723,22 @@
     "        postsynaptic['RMER'][nextState] = 2 + postsynaptic['RMER'][thisState]\n",
     "        postsynaptic['RMEV'][nextState] = 3 + postsynaptic['RMEV'][thisState]\n",
     "        postsynaptic['URAVR'][nextState] = 4 + postsynaptic['URAVR'][thisState]\n",
-    "        postsynaptic['URXR'][nextState] = 1 + postsynaptic['URXR'][thisState]\n",
-    "\n",
+    "        postsynaptic['URXR'][nextState] = 1 + postsynaptic['URXR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__LU__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def LUAL():\n",
     "        postsynaptic['AVAL'][nextState] = 6 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 6 + postsynaptic['AVAR'][thisState]\n",
@@ -2182,7 +2762,22 @@
     "        postsynaptic['PVCR'][nextState] = 3 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['PVR'][nextState] = 2 + postsynaptic['PVR'][thisState]\n",
     "        postsynaptic['PVWL'][nextState] = 1 + postsynaptic['PVWL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__M__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def M1():\n",
     "        postsynaptic['I2L'][nextState] = 2 + postsynaptic['I2L'][thisState]\n",
     "        postsynaptic['I2R'][nextState] = 2 + postsynaptic['I2R'][thisState]\n",
@@ -2286,7 +2881,22 @@
     "        postsynaptic['M3R'][nextState] = 1 + postsynaptic['M3R'][thisState]\n",
     "        postsynaptic['MCL'][nextState] = 2 + postsynaptic['MCL'][thisState]\n",
     "        postsynaptic['MCR'][nextState] = 2 + postsynaptic['MCR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__NS__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def NSML():\n",
     "        postsynaptic['I1L'][nextState] = 1 + postsynaptic['I1L'][thisState]\n",
     "        postsynaptic['I1R'][nextState] = 2 + postsynaptic['I1R'][thisState]\n",
@@ -2310,7 +2920,22 @@
     "        postsynaptic['I6'][nextState] = 2 + postsynaptic['I6'][thisState]\n",
     "        postsynaptic['M3L'][nextState] = 2 + postsynaptic['M3L'][thisState]\n",
     "        postsynaptic['M3R'][nextState] = 2 + postsynaptic['M3R'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__OL__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def OLLL():\n",
     "        postsynaptic['AVER'][nextState] = 21 + postsynaptic['AVER'][thisState]\n",
     "        postsynaptic['CEPDL'][nextState] = 3 + postsynaptic['CEPDL'][thisState]\n",
@@ -2398,7 +3023,22 @@
     "        postsynaptic['RMER'][nextState] = 1 + postsynaptic['RMER'][thisState]\n",
     "        postsynaptic['SIBDR'][nextState] = 4 + postsynaptic['SIBDR'][thisState]\n",
     "        postsynaptic['URBR'][nextState] = 1 + postsynaptic['URBR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__PD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def PDA():\n",
     "        postsynaptic['AS11'][nextState] = 1 + postsynaptic['AS11'][thisState]\n",
     "        postsynaptic['DA9'][nextState] = 1 + postsynaptic['DA9'][thisState]\n",
@@ -2435,7 +3075,22 @@
     "        postsynaptic['PVM'][nextState] = 1 + postsynaptic['PVM'][thisState]\n",
     "        postsynaptic['VA8'][nextState] = 1 + postsynaptic['VA8'][thisState]\n",
     "        postsynaptic['VD9'][nextState] = 1 + postsynaptic['VD9'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__PH__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def PHAL():\n",
     "        postsynaptic['AVDR'][nextState] = 1 + postsynaptic['AVDR'][thisState]\n",
     "        postsynaptic['AVFL'][nextState] = 3 + postsynaptic['AVFL'][thisState]\n",
@@ -2503,7 +3158,22 @@
     "        postsynaptic['PHCL'][nextState] = 2 + postsynaptic['PHCL'][thisState]\n",
     "        postsynaptic['PVCR'][nextState] = 9 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['VA12'][nextState] = 2 + postsynaptic['VA12'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__PL__, __PQ__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def PLML():\n",
     "        postsynaptic['HSNL'][nextState] = 1 + postsynaptic['HSNL'][thisState]\n",
     "        postsynaptic['LUAL'][nextState] = 1 + postsynaptic['LUAL'][thisState]\n",
@@ -2542,7 +3212,22 @@
     "        postsynaptic['LUAR'][nextState] = 1 + postsynaptic['LUAR'][thisState]\n",
     "        postsynaptic['PVNL'][nextState] = 1 + postsynaptic['PVNL'][thisState]\n",
     "        postsynaptic['PVPL'][nextState] = 4 + postsynaptic['PVPL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__PVC__ to __PVN__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def PVCL():\n",
     "        postsynaptic['AS1'][nextState] = 1 + postsynaptic['AS1'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 3 + postsynaptic['AVAL'][thisState]\n",
@@ -2695,8 +3380,22 @@
     "        postsynaptic['VC3'][nextState] = 1 + postsynaptic['VC3'][thisState]\n",
     "        postsynaptic['VD12'][nextState] = 1 + postsynaptic['VD12'][thisState]\n",
     "        postsynaptic['VD6'][nextState] = 1 + postsynaptic['VD6'][thisState]\n",
-    "        postsynaptic['VD7'][nextState] = 1 + postsynaptic['VD7'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD7'][nextState] = 1 + postsynaptic['VD7'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__PVP__ to __PVW__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def PVPL():\n",
     "        postsynaptic['ADAL'][nextState] = 1 + postsynaptic['ADAL'][thisState]\n",
     "        postsynaptic['AQR'][nextState] = 8 + postsynaptic['AQR'][thisState]\n",
@@ -2831,8 +3530,22 @@
     "        postsynaptic['AVDR'][nextState] = 1 + postsynaptic['AVDR'][thisState]\n",
     "        postsynaptic['PVCR'][nextState] = 2 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['PVT'][nextState] = 1 + postsynaptic['PVT'][thisState]\n",
-    "        postsynaptic['VA12'][nextState] = 1 + postsynaptic['VA12'][thisState]\n",
-    "\n",
+    "        postsynaptic['VA12'][nextState] = 1 + postsynaptic['VA12'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RIA__, __RIB__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RIAL():\n",
     "        postsynaptic['CEPVL'][nextState] = 1 + postsynaptic['CEPVL'][thisState]\n",
     "        postsynaptic['RIAR'][nextState] = 1 + postsynaptic['RIAR'][thisState]\n",
@@ -2920,8 +3633,22 @@
     "        postsynaptic['SMBDR'][nextState] = 1 + postsynaptic['SMBDR'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 2 + postsynaptic['SMDDL'][thisState]\n",
     "        postsynaptic['SMDDR'][nextState] = 1 + postsynaptic['SMDDR'][thisState]\n",
-    "        postsynaptic['SMDVL'][nextState] = 2 + postsynaptic['SMDVL'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDVL'][nextState] = 2 + postsynaptic['SMDVL'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RIC__ to __RIF__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RICL():\n",
     "        postsynaptic['ADAR'][nextState] = 1 + postsynaptic['ADAR'][thisState]\n",
     "        postsynaptic['ASHL'][nextState] = 2 + postsynaptic['ASHL'][thisState]\n",
@@ -2993,8 +3720,22 @@
     "        postsynaptic['PVCR'][nextState] = 1 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['PVPR'][nextState] = 4 + postsynaptic['PVPR'][thisState]\n",
     "        postsynaptic['RIMR'][nextState] = 4 + postsynaptic['RIMR'][thisState]\n",
-    "        postsynaptic['RIPR'][nextState] = 1 + postsynaptic['RIPR'][thisState]\n",
-    "\n",
+    "        postsynaptic['RIPR'][nextState] = 1 + postsynaptic['RIPR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RIG__ to __RIM__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RIGL():\n",
     "        postsynaptic['AIBR'][nextState] = 3 + postsynaptic['AIBR'][thisState]\n",
     "        postsynaptic['AIZR'][nextState] = 1 + postsynaptic['AIZR'][thisState]\n",
@@ -3112,8 +3853,22 @@
     "        postsynaptic['SAAVL'][nextState] = 3 + postsynaptic['SAAVL'][thisState]\n",
     "        postsynaptic['SAAVR'][nextState] = 3 + postsynaptic['SAAVR'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 2 + postsynaptic['SMDDL'][thisState]\n",
-    "        postsynaptic['SMDDR'][nextState] = 4 + postsynaptic['SMDDR'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDDR'][nextState] = 4 + postsynaptic['SMDDR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RIP__ to __RIV__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RIPL():\n",
     "        postsynaptic['OLQDL'][nextState] = 1 + postsynaptic['OLQDL'][thisState]\n",
     "        postsynaptic['OLQDR'][nextState] = 1 + postsynaptic['OLQDR'][thisState]\n",
@@ -3200,8 +3955,22 @@
     "        postsynaptic['SDQR'][nextState] = 2 + postsynaptic['SDQR'][thisState]\n",
     "        postsynaptic['SIAVL'][nextState] = 2 + postsynaptic['SIAVL'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 2 + postsynaptic['SMDDL'][thisState]\n",
-    "        postsynaptic['SMDVR'][nextState] = 4 + postsynaptic['SMDVR'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDVR'][nextState] = 4 + postsynaptic['SMDVR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RMD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RMDDL():\n",
     "        postsynaptic['MDR01'][nextState] = 1 + postsynaptic['MDR01'][thisState]\n",
     "        postsynaptic['MDR02'][nextState] = 1 + postsynaptic['MDR02'][thisState]\n",
@@ -3306,8 +4075,22 @@
     "        postsynaptic['SAAVR'][nextState] = 1 + postsynaptic['SAAVR'][thisState]\n",
     "        postsynaptic['SIBDR'][nextState] = 1 + postsynaptic['SIBDR'][thisState]\n",
     "        postsynaptic['SIBVR'][nextState] = 1 + postsynaptic['SIBVR'][thisState]\n",
-    "        postsynaptic['SMDVR'][nextState] = 1 + postsynaptic['SMDVR'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDVR'][nextState] = 1 + postsynaptic['SMDVR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RMED__ to __RMG__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RMED():\n",
     "        postsynaptic['IL1VL'][nextState] = 1 + postsynaptic['IL1VL'][thisState]\n",
     "        postsynaptic['MVL02'][nextState] = -4 + postsynaptic['MVL02'][thisState]\n",
@@ -3416,8 +4199,22 @@
     "        postsynaptic['RMDR'][nextState] = 2 + postsynaptic['RMDR'][thisState]\n",
     "        postsynaptic['RMDVR'][nextState] = 5 + postsynaptic['RMDVR'][thisState]\n",
     "        postsynaptic['RMHR'][nextState] = 1 + postsynaptic['RMHR'][thisState]\n",
-    "        postsynaptic['URXR'][nextState] = 2 + postsynaptic['URXR'][thisState]\n",
-    "\n",
+    "        postsynaptic['URXR'][nextState] = 2 + postsynaptic['URXR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__RMH__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def RMHL():\n",
     "        postsynaptic['MDR01'][nextState] = 2 + postsynaptic['MDR01'][thisState]\n",
     "        postsynaptic['MDR03'][nextState] = 3 + postsynaptic['MDR03'][thisState]\n",
@@ -3433,8 +4230,22 @@
     "        postsynaptic['MVL01'][nextState] = 2 + postsynaptic['MVL01'][thisState]\n",
     "        postsynaptic['RMER'][nextState] = 1 + postsynaptic['RMER'][thisState]\n",
     "        postsynaptic['RMGL'][nextState] = 1 + postsynaptic['RMGL'][thisState]\n",
-    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]\n",
-    "\n",
+    "        postsynaptic['RMGR'][nextState] = 1 + postsynaptic['RMGR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__SA__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def SAADL():\n",
     "        postsynaptic['AIBL'][nextState] = 1 + postsynaptic['AIBL'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 6 + postsynaptic['AVAL'][thisState]\n",
@@ -3488,7 +4299,22 @@
     "        postsynaptic['AVAL'][nextState] = 1 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['AVAR'][nextState] = 1 + postsynaptic['AVAR'][thisState]\n",
     "        postsynaptic['DA1'][nextState] = 3 + postsynaptic['DA1'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__SD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def SDQL():\n",
     "        postsynaptic['ALML'][nextState] = 2 + postsynaptic['ALML'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 1 + postsynaptic['AVAL'][thisState]\n",
@@ -3514,7 +4340,22 @@
     "        postsynaptic['RMHR'][nextState] = 1 + postsynaptic['RMHR'][thisState]\n",
     "        postsynaptic['SDQL'][nextState] = 1 + postsynaptic['SDQL'][thisState]\n",
     "        postsynaptic['SIBVL'][nextState] = 1 + postsynaptic['SIBVL'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__SI__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def SIADL():\n",
     "        postsynaptic['RIBL'][nextState] = 1 + postsynaptic['RIBL'][thisState]\n",
     "\n",
@@ -3548,7 +4389,22 @@
     "        postsynaptic['RIBR'][nextState] = 1 + postsynaptic['RIBR'][thisState]\n",
     "        postsynaptic['RMHL'][nextState] = 1 + postsynaptic['RMHL'][thisState]\n",
     "        postsynaptic['SIBDR'][nextState] = 1 + postsynaptic['SIBDR'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__SMB__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def SMBDL():\n",
     "        postsynaptic['AVAR'][nextState] = 1 + postsynaptic['AVAR'][thisState]\n",
     "        postsynaptic['AVKL'][nextState] = 1 + postsynaptic['AVKL'][thisState]\n",
@@ -3602,8 +4458,22 @@
     "        postsynaptic['MVR07'][nextState] = 1 + postsynaptic['MVR07'][thisState]\n",
     "        postsynaptic['RMEV'][nextState] = 3 + postsynaptic['RMEV'][thisState]\n",
     "        postsynaptic['SAADR'][nextState] = 4 + postsynaptic['SAADR'][thisState]\n",
-    "        postsynaptic['SAAVL'][nextState] = 3 + postsynaptic['SAAVL'][thisState]\n",
-    "\n",
+    "        postsynaptic['SAAVL'][nextState] = 3 + postsynaptic['SAAVL'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__SMD__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def SMDDL():\n",
     "        postsynaptic['MDL04'][nextState] = 1 + postsynaptic['MDL04'][thisState]\n",
     "        postsynaptic['MDL06'][nextState] = 1 + postsynaptic['MDL06'][thisState]\n",
@@ -3671,8 +4541,22 @@
     "        postsynaptic['RMDVR'][nextState] = 1 + postsynaptic['RMDVR'][thisState]\n",
     "        postsynaptic['SMDDL'][nextState] = 2 + postsynaptic['SMDDL'][thisState]\n",
     "        postsynaptic['SMDVL'][nextState] = 1 + postsynaptic['SMDVL'][thisState]\n",
-    "        postsynaptic['VB1'][nextState] = 1 + postsynaptic['VB1'][thisState]\n",
-    "\n",
+    "        postsynaptic['VB1'][nextState] = 1 + postsynaptic['VB1'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__URA__, __URB__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def URADL():\n",
     "        postsynaptic['IL1DL'][nextState] = 2 + postsynaptic['IL1DL'][thisState]\n",
     "        postsynaptic['MDL02'][nextState] = 2 + postsynaptic['MDL02'][thisState]\n",
@@ -3739,8 +4623,22 @@
     "        postsynaptic['RMFL'][nextState] = 1 + postsynaptic['RMFL'][thisState]\n",
     "        postsynaptic['SIAVR'][nextState] = 2 + postsynaptic['SIAVR'][thisState]\n",
     "        postsynaptic['SMBDL'][nextState] = 1 + postsynaptic['SMBDL'][thisState]\n",
-    "        postsynaptic['URXR'][nextState] = 4 + postsynaptic['URXR'][thisState]\n",
-    "\n",
+    "        postsynaptic['URXR'][nextState] = 4 + postsynaptic['URXR'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__URX__, __URY__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def URXL():\n",
     "        postsynaptic['ASHL'][nextState] = 1 + postsynaptic['ASHL'][thisState]\n",
     "        postsynaptic['AUAL'][nextState] = 5 + postsynaptic['AUAL'][thisState]\n",
@@ -3813,8 +4711,22 @@
     "        postsynaptic['RMDVL'][nextState] = 4 + postsynaptic['RMDVL'][thisState]\n",
     "        postsynaptic['SIBDR'][nextState] = 1 + postsynaptic['SIBDR'][thisState]\n",
     "        postsynaptic['SIBVL'][nextState] = 1 + postsynaptic['SIBVL'][thisState]\n",
-    "        postsynaptic['SMDVL'][nextState] = 3 + postsynaptic['SMDVL'][thisState]\n",
-    "\n",
+    "        postsynaptic['SMDVL'][nextState] = 3 + postsynaptic['SMDVL'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VA1__ to __VA6__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VA1():\n",
     "        postsynaptic['AVAL'][nextState] = 3 + postsynaptic['AVAL'][thisState]\n",
     "        postsynaptic['DA2'][nextState] = 2 + postsynaptic['DA2'][thisState]\n",
@@ -3824,6 +4736,7 @@
     "        postsynaptic['MVR07'][nextState] = 3 + postsynaptic['MVR07'][thisState]\n",
     "        postsynaptic['MVR08'][nextState] = 3 + postsynaptic['MVR08'][thisState]\n",
     "        postsynaptic['VD1'][nextState] = 2 + postsynaptic['VD1'][thisState]\n",
+    "\n",
     "\n",
     "def VA2():\n",
     "        postsynaptic['AVAL'][nextState] = 5 + postsynaptic['AVAL'][thisState]\n",
@@ -3894,8 +4807,22 @@
     "        postsynaptic['MVR14'][nextState] = 5 + postsynaptic['MVR14'][thisState]\n",
     "        postsynaptic['VB5'][nextState] = 2 + postsynaptic['VB5'][thisState]\n",
     "        postsynaptic['VD5'][nextState] = 1 + postsynaptic['VD5'][thisState]\n",
-    "        postsynaptic['VD6'][nextState] = 2 + postsynaptic['VD6'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD6'][nextState] = 2 + postsynaptic['VD6'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VA7__ to __VA12__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VA7():\n",
     "        postsynaptic['AS5'][nextState] = 1 + postsynaptic['AS5'][thisState]\n",
     "        postsynaptic['AVAL'][nextState] = 2 + postsynaptic['AVAL'][thisState]\n",
@@ -3996,8 +4923,22 @@
     "        postsynaptic['VA11'][nextState] = 1 + postsynaptic['VA11'][thisState]\n",
     "        postsynaptic['VB11'][nextState] = 1 + postsynaptic['VB11'][thisState]\n",
     "        postsynaptic['VD12'][nextState] = 3 + postsynaptic['VD12'][thisState]\n",
-    "        postsynaptic['VD13'][nextState] = 11 + postsynaptic['VD13'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD13'][nextState] = 11 + postsynaptic['VD13'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VB1__ to __VB6__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VB1():\n",
     "        postsynaptic['AIBR'][nextState] = 1 + postsynaptic['AIBR'][thisState]\n",
     "        postsynaptic['AVBL'][nextState] = 1 + postsynaptic['AVBL'][thisState]\n",
@@ -4097,8 +5038,22 @@
     "        postsynaptic['VB5'][nextState] = 1 + postsynaptic['VB5'][thisState]\n",
     "        postsynaptic['VB7'][nextState] = 1 + postsynaptic['VB7'][thisState]\n",
     "        postsynaptic['VD6'][nextState] = 1 + postsynaptic['VD6'][thisState]\n",
-    "        postsynaptic['VD7'][nextState] = 8 + postsynaptic['VD7'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD7'][nextState] = 8 + postsynaptic['VD7'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VB7__ to __VB11__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VB7():\n",
     "        postsynaptic['AVBL'][nextState] = 2 + postsynaptic['AVBL'][thisState]\n",
     "        postsynaptic['AVBR'][nextState] = 2 + postsynaptic['AVBR'][thisState]\n",
@@ -4168,8 +5123,22 @@
     "        postsynaptic['MVR23'][nextState] = 5 + postsynaptic['MVR23'][thisState]\n",
     "        postsynaptic['MVR24'][nextState] = 5 + postsynaptic['MVR24'][thisState]\n",
     "        postsynaptic['PVCR'][nextState] = 1 + postsynaptic['PVCR'][thisState]\n",
-    "        postsynaptic['VA12'][nextState] = 2 + postsynaptic['VA12'][thisState]\n",
-    "\n",
+    "        postsynaptic['VA12'][nextState] = 2 + postsynaptic['VA12'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VC__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VC1():\n",
     "        postsynaptic['AVL'][nextState] = 2 + postsynaptic['AVL'][thisState]\n",
     "        postsynaptic['DD1'][nextState] = 7 + postsynaptic['DD1'][thisState]\n",
@@ -4252,7 +5221,22 @@
     "\n",
     "def VC6():\n",
     "        postsynaptic['MVULVA'][nextState] = 1 + postsynaptic['MVULVA'][thisState]\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VD1__ to __VD6__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VD1():\n",
     "        postsynaptic['DD1'][nextState] = 5 + postsynaptic['DD1'][thisState]\n",
     "        postsynaptic['DVC'][nextState] = 5 + postsynaptic['DVC'][thisState]\n",
@@ -4322,8 +5306,22 @@
     "        postsynaptic['VA6'][nextState] = 1 + postsynaptic['VA6'][thisState]\n",
     "        postsynaptic['VB5'][nextState] = 2 + postsynaptic['VB5'][thisState]\n",
     "        postsynaptic['VD5'][nextState] = 2 + postsynaptic['VD5'][thisState]\n",
-    "        postsynaptic['VD7'][nextState] = 1 + postsynaptic['VD7'][thisState]\n",
-    "\n",
+    "        postsynaptic['VD7'][nextState] = 1 + postsynaptic['VD7'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__VD7__ to __VD13__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def VD7():\n",
     "        postsynaptic['MVL15'][nextState] = -7 + postsynaptic['MVL15'][thisState]\n",
     "        postsynaptic['MVL16'][nextState] = -7 + postsynaptic['MVL16'][thisState]\n",
@@ -4389,412 +5387,89 @@
     "        postsynaptic['PVCL'][nextState] = 1 + postsynaptic['PVCL'][thisState]\n",
     "        postsynaptic['PVCR'][nextState] = 1 + postsynaptic['PVCR'][thisState]\n",
     "        postsynaptic['PVPL'][nextState] = 2 + postsynaptic['PVPL'][thisState]\n",
-    "        postsynaptic['VA12'][nextState] = 1 + postsynaptic['VA12'][thisState]\n",
-    "\n",
-    "\n",
+    "        postsynaptic['VA12'][nextState] = 1 + postsynaptic['VA12'][thisState]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# From now on, the connectome has been defined and we deal with Python logic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__createpostsynaptic__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def createpostsynaptic():\n",
-    "        # The PostSynaptic dictionary maintains the accumulated values for\n",
-    "        # each neuron and muscle. The Accumulated values are initialized to Zero\n",
-    "        postsynaptic['ADAL'] = [0,0]\n",
-    "        postsynaptic['ADAR'] = [0,0]\n",
-    "        postsynaptic['ADEL'] = [0,0]\n",
-    "        postsynaptic['ADER'] = [0,0]\n",
-    "        postsynaptic['ADFL'] = [0,0]\n",
-    "        postsynaptic['ADFR'] = [0,0]\n",
-    "        postsynaptic['ADLL'] = [0,0]\n",
-    "        postsynaptic['ADLR'] = [0,0]\n",
-    "        postsynaptic['AFDL'] = [0,0]\n",
-    "        postsynaptic['AFDR'] = [0,0]\n",
-    "        postsynaptic['AIAL'] = [0,0]\n",
-    "        postsynaptic['AIAR'] = [0,0]\n",
-    "        postsynaptic['AIBL'] = [0,0]\n",
-    "        postsynaptic['AIBR'] = [0,0]\n",
-    "        postsynaptic['AIML'] = [0,0]\n",
-    "        postsynaptic['AIMR'] = [0,0]\n",
-    "        postsynaptic['AINL'] = [0,0]\n",
-    "        postsynaptic['AINR'] = [0,0]\n",
-    "        postsynaptic['AIYL'] = [0,0]\n",
-    "        postsynaptic['AIYR'] = [0,0]\n",
-    "        postsynaptic['AIZL'] = [0,0]\n",
-    "        postsynaptic['AIZR'] = [0,0]\n",
-    "        postsynaptic['ALA'] = [0,0]\n",
-    "        postsynaptic['ALML'] = [0,0]\n",
-    "        postsynaptic['ALMR'] = [0,0]\n",
-    "        postsynaptic['ALNL'] = [0,0]\n",
-    "        postsynaptic['ALNR'] = [0,0]\n",
-    "        postsynaptic['AQR'] = [0,0]\n",
-    "        postsynaptic['AS1'] = [0,0]\n",
-    "        postsynaptic['AS10'] = [0,0]\n",
-    "        postsynaptic['AS11'] = [0,0]\n",
-    "        postsynaptic['AS2'] = [0,0]\n",
-    "        postsynaptic['AS3'] = [0,0]\n",
-    "        postsynaptic['AS4'] = [0,0]\n",
-    "        postsynaptic['AS5'] = [0,0]\n",
-    "        postsynaptic['AS6'] = [0,0]\n",
-    "        postsynaptic['AS7'] = [0,0]\n",
-    "        postsynaptic['AS8'] = [0,0]\n",
-    "        postsynaptic['AS9'] = [0,0]\n",
-    "        postsynaptic['ASEL'] = [0,0]\n",
-    "        postsynaptic['ASER'] = [0,0]\n",
-    "        postsynaptic['ASGL'] = [0,0]\n",
-    "        postsynaptic['ASGR'] = [0,0]\n",
-    "        postsynaptic['ASHL'] = [0,0]\n",
-    "        postsynaptic['ASHR'] = [0,0]\n",
-    "        postsynaptic['ASIL'] = [0,0]\n",
-    "        postsynaptic['ASIR'] = [0,0]\n",
-    "        postsynaptic['ASJL'] = [0,0]\n",
-    "        postsynaptic['ASJR'] = [0,0]\n",
-    "        postsynaptic['ASKL'] = [0,0]\n",
-    "        postsynaptic['ASKR'] = [0,0]\n",
-    "        postsynaptic['AUAL'] = [0,0]\n",
-    "        postsynaptic['AUAR'] = [0,0]\n",
-    "        postsynaptic['AVAL'] = [0,0]\n",
-    "        postsynaptic['AVAR'] = [0,0]\n",
-    "        postsynaptic['AVBL'] = [0,0]\n",
-    "        postsynaptic['AVBR'] = [0,0]\n",
-    "        postsynaptic['AVDL'] = [0,0]\n",
-    "        postsynaptic['AVDR'] = [0,0]\n",
-    "        postsynaptic['AVEL'] = [0,0]\n",
-    "        postsynaptic['AVER'] = [0,0]\n",
-    "        postsynaptic['AVFL'] = [0,0]\n",
-    "        postsynaptic['AVFR'] = [0,0]\n",
-    "        postsynaptic['AVG'] = [0,0]\n",
-    "        postsynaptic['AVHL'] = [0,0]\n",
-    "        postsynaptic['AVHR'] = [0,0]\n",
-    "        postsynaptic['AVJL'] = [0,0]\n",
-    "        postsynaptic['AVJR'] = [0,0]\n",
-    "        postsynaptic['AVKL'] = [0,0]\n",
-    "        postsynaptic['AVKR'] = [0,0]\n",
-    "        postsynaptic['AVL'] = [0,0]\n",
-    "        postsynaptic['AVM'] = [0,0]\n",
-    "        postsynaptic['AWAL'] = [0,0]\n",
-    "        postsynaptic['AWAR'] = [0,0]\n",
-    "        postsynaptic['AWBL'] = [0,0]\n",
-    "        postsynaptic['AWBR'] = [0,0]\n",
-    "        postsynaptic['AWCL'] = [0,0]\n",
-    "        postsynaptic['AWCR'] = [0,0]\n",
-    "        postsynaptic['BAGL'] = [0,0]\n",
-    "        postsynaptic['BAGR'] = [0,0]\n",
-    "        postsynaptic['BDUL'] = [0,0]\n",
-    "        postsynaptic['BDUR'] = [0,0]\n",
-    "        postsynaptic['CEPDL'] = [0,0]\n",
-    "        postsynaptic['CEPDR'] = [0,0]\n",
-    "        postsynaptic['CEPVL'] = [0,0]\n",
-    "        postsynaptic['CEPVR'] = [0,0]\n",
-    "        postsynaptic['DA1'] = [0,0]\n",
-    "        postsynaptic['DA2'] = [0,0]\n",
-    "        postsynaptic['DA3'] = [0,0]\n",
-    "        postsynaptic['DA4'] = [0,0]\n",
-    "        postsynaptic['DA5'] = [0,0]\n",
-    "        postsynaptic['DA6'] = [0,0]\n",
-    "        postsynaptic['DA7'] = [0,0]\n",
-    "        postsynaptic['DA8'] = [0,0]\n",
-    "        postsynaptic['DA9'] = [0,0]\n",
-    "        postsynaptic['DB1'] = [0,0]\n",
-    "        postsynaptic['DB2'] = [0,0]\n",
-    "        postsynaptic['DB3'] = [0,0]\n",
-    "        postsynaptic['DB4'] = [0,0]\n",
-    "        postsynaptic['DB5'] = [0,0]\n",
-    "        postsynaptic['DB6'] = [0,0]\n",
-    "        postsynaptic['DB7'] = [0,0]\n",
-    "        postsynaptic['DD1'] = [0,0]\n",
-    "        postsynaptic['DD2'] = [0,0]\n",
-    "        postsynaptic['DD3'] = [0,0]\n",
-    "        postsynaptic['DD4'] = [0,0]\n",
-    "        postsynaptic['DD5'] = [0,0]\n",
-    "        postsynaptic['DD6'] = [0,0]\n",
-    "        postsynaptic['DVA'] = [0,0]\n",
-    "        postsynaptic['DVB'] = [0,0]\n",
-    "        postsynaptic['DVC'] = [0,0]\n",
-    "        postsynaptic['FLPL'] = [0,0]\n",
-    "        postsynaptic['FLPR'] = [0,0]\n",
-    "        postsynaptic['HSNL'] = [0,0]\n",
-    "        postsynaptic['HSNR'] = [0,0]\n",
-    "        postsynaptic['I1L'] = [0,0]\n",
-    "        postsynaptic['I1R'] = [0,0]\n",
-    "        postsynaptic['I2L'] = [0,0]\n",
-    "        postsynaptic['I2R'] = [0,0]\n",
-    "        postsynaptic['I3'] = [0,0]\n",
-    "        postsynaptic['I4'] = [0,0]\n",
-    "        postsynaptic['I5'] = [0,0]\n",
-    "        postsynaptic['I6'] = [0,0]\n",
-    "        postsynaptic['IL1DL'] = [0,0]\n",
-    "        postsynaptic['IL1DR'] = [0,0]\n",
-    "        postsynaptic['IL1L'] = [0,0]\n",
-    "        postsynaptic['IL1R'] = [0,0]\n",
-    "        postsynaptic['IL1VL'] = [0,0]\n",
-    "        postsynaptic['IL1VR'] = [0,0]\n",
-    "        postsynaptic['IL2L'] = [0,0]\n",
-    "        postsynaptic['IL2R'] = [0,0]\n",
-    "        postsynaptic['IL2DL'] = [0,0]\n",
-    "        postsynaptic['IL2DR'] = [0,0]\n",
-    "        postsynaptic['IL2VL'] = [0,0]\n",
-    "        postsynaptic['IL2VR'] = [0,0]\n",
-    "        postsynaptic['LUAL'] = [0,0]\n",
-    "        postsynaptic['LUAR'] = [0,0]\n",
-    "        postsynaptic['M1'] = [0,0]\n",
-    "        postsynaptic['M2L'] = [0,0]\n",
-    "        postsynaptic['M2R'] = [0,0]\n",
-    "        postsynaptic['M3L'] = [0,0]\n",
-    "        postsynaptic['M3R'] = [0,0]\n",
-    "        postsynaptic['M4'] = [0,0]\n",
-    "        postsynaptic['M5'] = [0,0]\n",
-    "        postsynaptic['MANAL'] = [0,0]\n",
-    "        postsynaptic['MCL'] = [0,0]\n",
-    "        postsynaptic['MCR'] = [0,0]\n",
-    "        postsynaptic['MDL01'] = [0,0]\n",
-    "        postsynaptic['MDL02'] = [0,0]\n",
-    "        postsynaptic['MDL03'] = [0,0]\n",
-    "        postsynaptic['MDL04'] = [0,0]\n",
-    "        postsynaptic['MDL05'] = [0,0]\n",
-    "        postsynaptic['MDL06'] = [0,0]\n",
-    "        postsynaptic['MDL07'] = [0,0]\n",
-    "        postsynaptic['MDL08'] = [0,0]\n",
-    "        postsynaptic['MDL09'] = [0,0]\n",
-    "        postsynaptic['MDL10'] = [0,0]\n",
-    "        postsynaptic['MDL11'] = [0,0]\n",
-    "        postsynaptic['MDL12'] = [0,0]\n",
-    "        postsynaptic['MDL13'] = [0,0]\n",
-    "        postsynaptic['MDL14'] = [0,0]\n",
-    "        postsynaptic['MDL15'] = [0,0]\n",
-    "        postsynaptic['MDL16'] = [0,0]\n",
-    "        postsynaptic['MDL17'] = [0,0]\n",
-    "        postsynaptic['MDL18'] = [0,0]\n",
-    "        postsynaptic['MDL19'] = [0,0]\n",
-    "        postsynaptic['MDL20'] = [0,0]\n",
-    "        postsynaptic['MDL21'] = [0,0]\n",
-    "        postsynaptic['MDL22'] = [0,0]\n",
-    "        postsynaptic['MDL23'] = [0,0]\n",
-    "        postsynaptic['MDL24'] = [0,0]\n",
-    "        postsynaptic['MDR01'] = [0,0]\n",
-    "        postsynaptic['MDR02'] = [0,0]\n",
-    "        postsynaptic['MDR03'] = [0,0]\n",
-    "        postsynaptic['MDR04'] = [0,0]\n",
-    "        postsynaptic['MDR05'] = [0,0]\n",
-    "        postsynaptic['MDR06'] = [0,0]\n",
-    "        postsynaptic['MDR07'] = [0,0]\n",
-    "        postsynaptic['MDR08'] = [0,0]\n",
-    "        postsynaptic['MDR09'] = [0,0]\n",
-    "        postsynaptic['MDR10'] = [0,0]\n",
-    "        postsynaptic['MDR11'] = [0,0]\n",
-    "        postsynaptic['MDR12'] = [0,0]\n",
-    "        postsynaptic['MDR13'] = [0,0]\n",
-    "        postsynaptic['MDR14'] = [0,0]\n",
-    "        postsynaptic['MDR15'] = [0,0]\n",
-    "        postsynaptic['MDR16'] = [0,0]\n",
-    "        postsynaptic['MDR17'] = [0,0]\n",
-    "        postsynaptic['MDR18'] = [0,0]\n",
-    "        postsynaptic['MDR19'] = [0,0]\n",
-    "        postsynaptic['MDR20'] = [0,0]\n",
-    "        postsynaptic['MDR21'] = [0,0]\n",
-    "        postsynaptic['MDR22'] = [0,0]\n",
-    "        postsynaptic['MDR23'] = [0,0]\n",
-    "        postsynaptic['MDR24'] = [0,0]\n",
-    "        postsynaptic['MI'] = [0,0]\n",
-    "        postsynaptic['MVL01'] = [0,0]\n",
-    "        postsynaptic['MVL02'] = [0,0]\n",
-    "        postsynaptic['MVL03'] = [0,0]\n",
-    "        postsynaptic['MVL04'] = [0,0]\n",
-    "        postsynaptic['MVL05'] = [0,0]\n",
-    "        postsynaptic['MVL06'] = [0,0]\n",
-    "        postsynaptic['MVL07'] = [0,0]\n",
-    "        postsynaptic['MVL08'] = [0,0]\n",
-    "        postsynaptic['MVL09'] = [0,0]\n",
-    "        postsynaptic['MVL10'] = [0,0]\n",
-    "        postsynaptic['MVL11'] = [0,0]\n",
-    "        postsynaptic['MVL12'] = [0,0]\n",
-    "        postsynaptic['MVL13'] = [0,0]\n",
-    "        postsynaptic['MVL14'] = [0,0]\n",
-    "        postsynaptic['MVL15'] = [0,0]\n",
-    "        postsynaptic['MVL16'] = [0,0]\n",
-    "        postsynaptic['MVL17'] = [0,0]\n",
-    "        postsynaptic['MVL18'] = [0,0]\n",
-    "        postsynaptic['MVL19'] = [0,0]\n",
-    "        postsynaptic['MVL20'] = [0,0]\n",
-    "        postsynaptic['MVL21'] = [0,0]\n",
-    "        postsynaptic['MVL22'] = [0,0]\n",
-    "        postsynaptic['MVL23'] = [0,0]\n",
-    "        postsynaptic['MVR01'] = [0,0]\n",
-    "        postsynaptic['MVR02'] = [0,0]\n",
-    "        postsynaptic['MVR03'] = [0,0]\n",
-    "        postsynaptic['MVR04'] = [0,0]\n",
-    "        postsynaptic['MVR05'] = [0,0]\n",
-    "        postsynaptic['MVR06'] = [0,0]\n",
-    "        postsynaptic['MVR07'] = [0,0]\n",
-    "        postsynaptic['MVR08'] = [0,0]\n",
-    "        postsynaptic['MVR09'] = [0,0]\n",
-    "        postsynaptic['MVR10'] = [0,0]\n",
-    "        postsynaptic['MVR11'] = [0,0]\n",
-    "        postsynaptic['MVR12'] = [0,0]\n",
-    "        postsynaptic['MVR13'] = [0,0]\n",
-    "        postsynaptic['MVR14'] = [0,0]\n",
-    "        postsynaptic['MVR15'] = [0,0]\n",
-    "        postsynaptic['MVR16'] = [0,0]\n",
-    "        postsynaptic['MVR17'] = [0,0]\n",
-    "        postsynaptic['MVR18'] = [0,0]\n",
-    "        postsynaptic['MVR19'] = [0,0]\n",
-    "        postsynaptic['MVR20'] = [0,0]\n",
-    "        postsynaptic['MVR21'] = [0,0]\n",
-    "        postsynaptic['MVR22'] = [0,0]\n",
-    "        postsynaptic['MVR23'] = [0,0]\n",
-    "        postsynaptic['MVR24'] = [0,0]\n",
-    "        postsynaptic['MVULVA'] = [0,0]\n",
-    "        postsynaptic['NSML'] = [0,0]\n",
-    "        postsynaptic['NSMR'] = [0,0]\n",
-    "        postsynaptic['OLLL'] = [0,0]\n",
-    "        postsynaptic['OLLR'] = [0,0]\n",
-    "        postsynaptic['OLQDL'] = [0,0]\n",
-    "        postsynaptic['OLQDR'] = [0,0]\n",
-    "        postsynaptic['OLQVL'] = [0,0]\n",
-    "        postsynaptic['OLQVR'] = [0,0]\n",
-    "        postsynaptic['PDA'] = [0,0]\n",
-    "        postsynaptic['PDB'] = [0,0]\n",
-    "        postsynaptic['PDEL'] = [0,0]\n",
-    "        postsynaptic['PDER'] = [0,0]\n",
-    "        postsynaptic['PHAL'] = [0,0]\n",
-    "        postsynaptic['PHAR'] = [0,0]\n",
-    "        postsynaptic['PHBL'] = [0,0]\n",
-    "        postsynaptic['PHBR'] = [0,0]\n",
-    "        postsynaptic['PHCL'] = [0,0]\n",
-    "        postsynaptic['PHCR'] = [0,0]\n",
-    "        postsynaptic['PLML'] = [0,0]\n",
-    "        postsynaptic['PLMR'] = [0,0]\n",
-    "        postsynaptic['PLNL'] = [0,0]\n",
-    "        postsynaptic['PLNR'] = [0,0]\n",
-    "        postsynaptic['PQR'] = [0,0]\n",
-    "        postsynaptic['PVCL'] = [0,0]\n",
-    "        postsynaptic['PVCR'] = [0,0]\n",
-    "        postsynaptic['PVDL'] = [0,0]\n",
-    "        postsynaptic['PVDR'] = [0,0]\n",
-    "        postsynaptic['PVM'] = [0,0]\n",
-    "        postsynaptic['PVNL'] = [0,0]\n",
-    "        postsynaptic['PVNR'] = [0,0]\n",
-    "        postsynaptic['PVPL'] = [0,0]\n",
-    "        postsynaptic['PVPR'] = [0,0]\n",
-    "        postsynaptic['PVQL'] = [0,0]\n",
-    "        postsynaptic['PVQR'] = [0,0]\n",
-    "        postsynaptic['PVR'] = [0,0]\n",
-    "        postsynaptic['PVT'] = [0,0]\n",
-    "        postsynaptic['PVWL'] = [0,0]\n",
-    "        postsynaptic['PVWR'] = [0,0]\n",
-    "        postsynaptic['RIAL'] = [0,0]\n",
-    "        postsynaptic['RIAR'] = [0,0]\n",
-    "        postsynaptic['RIBL'] = [0,0]\n",
-    "        postsynaptic['RIBR'] = [0,0]\n",
-    "        postsynaptic['RICL'] = [0,0]\n",
-    "        postsynaptic['RICR'] = [0,0]\n",
-    "        postsynaptic['RID'] = [0,0]\n",
-    "        postsynaptic['RIFL'] = [0,0]\n",
-    "        postsynaptic['RIFR'] = [0,0]\n",
-    "        postsynaptic['RIGL'] = [0,0]\n",
-    "        postsynaptic['RIGR'] = [0,0]\n",
-    "        postsynaptic['RIH'] = [0,0]\n",
-    "        postsynaptic['RIML'] = [0,0]\n",
-    "        postsynaptic['RIMR'] = [0,0]\n",
-    "        postsynaptic['RIPL'] = [0,0]\n",
-    "        postsynaptic['RIPR'] = [0,0]\n",
-    "        postsynaptic['RIR'] = [0,0]\n",
-    "        postsynaptic['RIS'] = [0,0]\n",
-    "        postsynaptic['RIVL'] = [0,0]\n",
-    "        postsynaptic['RIVR'] = [0,0]\n",
-    "        postsynaptic['RMDDL'] = [0,0]\n",
-    "        postsynaptic['RMDDR'] = [0,0]\n",
-    "        postsynaptic['RMDL'] = [0,0]\n",
-    "        postsynaptic['RMDR'] = [0,0]\n",
-    "        postsynaptic['RMDVL'] = [0,0]\n",
-    "        postsynaptic['RMDVR'] = [0,0]\n",
-    "        postsynaptic['RMED'] = [0,0]\n",
-    "        postsynaptic['RMEL'] = [0,0]\n",
-    "        postsynaptic['RMER'] = [0,0]\n",
-    "        postsynaptic['RMEV'] = [0,0]\n",
-    "        postsynaptic['RMFL'] = [0,0]\n",
-    "        postsynaptic['RMFR'] = [0,0]\n",
-    "        postsynaptic['RMGL'] = [0,0]\n",
-    "        postsynaptic['RMGR'] = [0,0]\n",
-    "        postsynaptic['RMHL'] = [0,0]\n",
-    "        postsynaptic['RMHR'] = [0,0]\n",
-    "        postsynaptic['SAADL'] = [0,0]\n",
-    "        postsynaptic['SAADR'] = [0,0]\n",
-    "        postsynaptic['SAAVL'] = [0,0]\n",
-    "        postsynaptic['SAAVR'] = [0,0]\n",
-    "        postsynaptic['SABD'] = [0,0]\n",
-    "        postsynaptic['SABVL'] = [0,0]\n",
-    "        postsynaptic['SABVR'] = [0,0]\n",
-    "        postsynaptic['SDQL'] = [0,0]\n",
-    "        postsynaptic['SDQR'] = [0,0]\n",
-    "        postsynaptic['SIADL'] = [0,0]\n",
-    "        postsynaptic['SIADR'] = [0,0]\n",
-    "        postsynaptic['SIAVL'] = [0,0]\n",
-    "        postsynaptic['SIAVR'] = [0,0]\n",
-    "        postsynaptic['SIBDL'] = [0,0]\n",
-    "        postsynaptic['SIBDR'] = [0,0]\n",
-    "        postsynaptic['SIBVL'] = [0,0]\n",
-    "        postsynaptic['SIBVR'] = [0,0]\n",
-    "        postsynaptic['SMBDL'] = [0,0]\n",
-    "        postsynaptic['SMBDR'] = [0,0]\n",
-    "        postsynaptic['SMBVL'] = [0,0]\n",
-    "        postsynaptic['SMBVR'] = [0,0]\n",
-    "        postsynaptic['SMDDL'] = [0,0]\n",
-    "        postsynaptic['SMDDR'] = [0,0]\n",
-    "        postsynaptic['SMDVL'] = [0,0]\n",
-    "        postsynaptic['SMDVR'] = [0,0]\n",
-    "        postsynaptic['URADL'] = [0,0]\n",
-    "        postsynaptic['URADR'] = [0,0]\n",
-    "        postsynaptic['URAVL'] = [0,0]\n",
-    "        postsynaptic['URAVR'] = [0,0]\n",
-    "        postsynaptic['URBL'] = [0,0]\n",
-    "        postsynaptic['URBR'] = [0,0]\n",
-    "        postsynaptic['URXL'] = [0,0]\n",
-    "        postsynaptic['URXR'] = [0,0]\n",
-    "        postsynaptic['URYDL'] = [0,0]\n",
-    "        postsynaptic['URYDR'] = [0,0]\n",
-    "        postsynaptic['URYVL'] = [0,0]\n",
-    "        postsynaptic['URYVR'] = [0,0]\n",
-    "        postsynaptic['VA1'] = [0,0]\n",
-    "        postsynaptic['VA10'] = [0,0]\n",
-    "        postsynaptic['VA11'] = [0,0]\n",
-    "        postsynaptic['VA12'] = [0,0]\n",
-    "        postsynaptic['VA2'] = [0,0]\n",
-    "        postsynaptic['VA3'] = [0,0]\n",
-    "        postsynaptic['VA4'] = [0,0]\n",
-    "        postsynaptic['VA5'] = [0,0]\n",
-    "        postsynaptic['VA6'] = [0,0]\n",
-    "        postsynaptic['VA7'] = [0,0]\n",
-    "        postsynaptic['VA8'] = [0,0]\n",
-    "        postsynaptic['VA9'] = [0,0]\n",
-    "        postsynaptic['VB1'] = [0,0]\n",
-    "        postsynaptic['VB10'] = [0,0]\n",
-    "        postsynaptic['VB11'] = [0,0]\n",
-    "        postsynaptic['VB2'] = [0,0]\n",
-    "        postsynaptic['VB3'] = [0,0]\n",
-    "        postsynaptic['VB4'] = [0,0]\n",
-    "        postsynaptic['VB5'] = [0,0]\n",
-    "        postsynaptic['VB6'] = [0,0]\n",
-    "        postsynaptic['VB7'] = [0,0]\n",
-    "        postsynaptic['VB8'] = [0,0]\n",
-    "        postsynaptic['VB9'] = [0,0]\n",
-    "        postsynaptic['VC1'] = [0,0]\n",
-    "        postsynaptic['VC2'] = [0,0]\n",
-    "        postsynaptic['VC3'] = [0,0]\n",
-    "        postsynaptic['VC4'] = [0,0]\n",
-    "        postsynaptic['VC5'] = [0,0]\n",
-    "        postsynaptic['VC6'] = [0,0]\n",
-    "        postsynaptic['VD1'] = [0,0]\n",
-    "        postsynaptic['VD10'] = [0,0]\n",
-    "        postsynaptic['VD11'] = [0,0]\n",
-    "        postsynaptic['VD12'] = [0,0]\n",
-    "        postsynaptic['VD13'] = [0,0]\n",
-    "        postsynaptic['VD2'] = [0,0]\n",
-    "        postsynaptic['VD3'] = [0,0]\n",
-    "        postsynaptic['VD4'] = [0,0]\n",
-    "        postsynaptic['VD5'] = [0,0]\n",
-    "        postsynaptic['VD6'] = [0,0]\n",
-    "        postsynaptic['VD7'] = [0,0]\n",
-    "        postsynaptic['VD8'] = [0,0]\n",
-    "        postsynaptic['VD9'] = [0,0]\n",
+    "    global postsynaptic\n",
+    "    \n",
+    "    postsynaptic_keys = ['ADAL', 'ADAR', 'ADEL', 'ADER', 'ADFL', 'ADFR', 'ADLL', 'ADLR', 'AFDL', 'AFDR', \n",
+    "                     'AIAL', 'AIAR', 'AIBL', 'AIBR', 'AIML', 'AIMR', 'AINL', 'AINR', 'AIYL', 'AIYR', \n",
+    "                     'AIZL', 'AIZR', 'ALA', 'ALML', 'ALMR', 'ALNL', 'ALNR', 'AQR', 'AS1', 'AS10', 'AS11', \n",
+    "                     'AS2', 'AS3', 'AS4', 'AS5', 'AS6', 'AS7', 'AS8', 'AS9', 'ASEL', 'ASER', 'ASGL', \n",
+    "                     'ASGR', 'ASHL', 'ASHR', 'ASIL', 'ASIR', 'ASJL', 'ASJR', 'ASKL', 'ASKR', 'AUAL', \n",
+    "                     'AUAR', 'AVAL', 'AVAR', 'AVBL', 'AVBR', 'AVDL', 'AVDR', 'AVEL', 'AVER', 'AVFL', \n",
+    "                     'AVFR', 'AVG', 'AVHL', 'AVHR', 'AVJL', 'AVJR', 'AVKL', 'AVKR', 'AVL', 'AVM', 'AWAL', \n",
+    "                     'AWAR', 'AWBL', 'AWBR', 'AWCL', 'AWCR', 'BAGL', 'BAGR', 'BDUL', 'BDUR', 'CEPDL', \n",
+    "                     'CEPDR', 'CEPVL', 'CEPVR', 'DA1', 'DA2', 'DA3', 'DA4', 'DA5', 'DA6', 'DA7', 'DA8', \n",
+    "                     'DA9', 'DB1', 'DB2', 'DB3', 'DB4', 'DB5', 'DB6', 'DB7', 'DD1', 'DD2', 'DD3', 'DD4', \n",
+    "                     'DD5', 'DD6', 'DVA', 'DVB', 'DVC', 'FLPL', 'FLPR', 'HSNL', 'HSNR', 'I1L', 'I1R', \n",
+    "                     'I2L', 'I2R', 'I3', 'I4', 'I5', 'I6', 'IL1DL', 'IL1DR', 'IL1L', 'IL1R', 'IL1VL', \n",
+    "                     'IL1VR', 'IL2L', 'IL2R', 'IL2DL', 'IL2DR', 'IL2VL', 'IL2VR', 'LUAL', 'LUAR', 'M1', \n",
+    "                     'M2L', 'M2R', 'M3L', 'M3R', 'M4', 'M5', 'MANAL', 'MCL', 'MCR', 'MDL01', 'MDL02', \n",
+    "                     'MDL03', 'MDL04', 'MDL05', 'MDL06', 'MDL07', 'MDL08', 'MDL09', 'MDL10', 'MDL11', \n",
+    "                     'MDL12', 'MDL13', 'MDL14', 'MDL15', 'MDL16', 'MDL17', 'MDL18', 'MDL19', 'MDL20', \n",
+    "                     'MDL21', 'MDL22', 'MDL23', 'MDL24', 'MDR01', 'MDR02', 'MDR03', 'MDR04', 'MDR05', \n",
+    "                     'MDR06', 'MDR07', 'MDR08', 'MDR09', 'MDR10', 'MDR11', 'MDR12', 'MDR13', 'MDR14', \n",
+    "                     'MDR15', 'MDR16', 'MDR17', 'MDR18', 'MDR19', 'MDR20', 'MDR21', 'MDR22', 'MDR23', \n",
+    "                     'MDR24', 'MI', 'MVL01', 'MVL02', 'MVL03', 'MVL04', 'MVL05', 'MVL06', 'MVL07', 'MVL08', \n",
+    "                     'MVL09', 'MVL10', 'MVL11', 'MVL12', 'MVL13', 'MVL14', 'MVL15', 'MVL16', 'MVL17', 'MVL18', \n",
+    "                     'MVL19', 'MVL20', 'MVL21', 'MVL22', 'MVL23', 'MVR01', 'MVR02', 'MVR03', 'MVR04', 'MVR05', \n",
+    "                     'MVR06', 'MVR07', 'MVR08', 'MVR09', 'MVR10', 'MVR11', 'MVR12', 'MVR13', 'MVR14', 'MVR15', \n",
+    "                     'MVR16', 'MVR17', 'MVR18', 'MVR19', 'MVR20', 'MVR21', 'MVR22', 'MVR23', 'MVR24', 'MVULVA', \n",
+    "                     'NSML', 'NSMR', 'OLLL', 'OLLR', 'OLQDL', 'OLQDR', 'OLQVL', 'OLQVR', 'PDA', 'PDB', 'PDEL', \n",
+    "                     'PDER', 'PHAL', 'PHAR', 'PHBL', 'PHBR', 'PHCL', 'PHCR', 'PLML', 'PLMR', 'PLNL', 'PLNR', \n",
+    "                     'PQR', 'PVCL', 'PVCR', 'PVDL', 'PVDR', 'PVM', 'PVNL', 'PVNR', 'PVPL', 'PVPR', 'PVQL', \n",
+    "                     'PVQR', 'PVR', 'PVT', 'PVWL', 'PVWR', 'RIAL', 'RIAR', 'RIBL', 'RIBR', 'RICL', 'RICR', \n",
+    "                     'RID', 'RIFL', 'RIFR', 'RIGL', 'RIGR', 'RIH', 'RIML', 'RIMR', 'RIPL', 'RIPR', 'RIR', 'RIS', \n",
+    "                     'RIVL', 'RIVR', 'RMDDL', 'RMDDR', 'RMDL', 'RMDR', 'RMDVL', 'RMDVR', 'RMED', 'RMEL', 'RMER', \n",
+    "                     'RMEV', 'RMFL', 'RMFR', 'RMGL', 'RMGR', 'RMHL', 'RMHR', 'SAADL', 'SAADR', 'SAAVL', 'SAAVR', \n",
+    "                     'SABD', 'SABVL', 'SABVR', 'SDQL', 'SDQR', 'SIADL', 'SIADR', 'SIAVL', 'SIAVR', 'SIBDL', \n",
+    "                     'SIBDR', 'SIBVL', 'SIBVR', 'SMBDL', 'SMBDR', 'SMBVL', 'SMBVR', 'SMDDL', 'SMDDR', 'SMDVL', \n",
+    "                     'SMDVR', 'URADL', 'URADR', 'URAVL', 'URAVR', 'URBL', 'URBR', 'URXL', 'URXR', 'URYDL', \n",
+    "                     'URYDR', 'URYVL', 'URYVR', 'VA1', 'VA10', 'VA11', 'VA12', 'VA2', 'VA3', 'VA4', 'VA5', 'VA6', 'VA7', 'VA8', 'VA9', \n",
+    "                     'VB1', 'VB10', 'VB11', 'VB2', 'VB3', 'VB4', 'VB5', 'VB6', 'VB7', 'VB8', 'VB9', \n",
+    "                     'VC1', 'VC2', 'VC3', 'VC4', 'VC5', 'VC6', \n",
+    "                     'VD1', 'VD10', 'VD11', 'VD12', 'VD13', 'VD2', 'VD3', 'VD4', 'VD5', 'VD6', 'VD7', 'VD8', 'VD9']\n",
     "\n",
-    "#global postsynapticNext = copy.deepcopy(postsynaptic)\n",
-    "\n",
+    "    postsynaptic = {key: [0,0] for key in postsynaptic_keys}\n",
+    "    #print(list(postsynaptic.keys()))\n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__motorcontrol__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def motorcontrol():\n",
     "        global accumright\n",
     "        global accumleft\n",
@@ -4856,9 +5531,22 @@
     "         ## End Commented section\n",
     "        accumleft = 0\n",
     "        accumright = 0\n",
-    "        time.sleep(0.5)\n",
-    "\n",
-    "\n",
+    "        time.sleep(0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Accumulate, fire neurons, and run connectome__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def dendriteAccumulate(dneuron):\n",
     "        f = eval(dneuron)\n",
     "        f()\n",
@@ -4882,13 +5570,27 @@
     "                        fireNeuron(ps)\n",
     "                        postsynaptic[ps] = [0,0]\n",
     "        motorcontrol()\n",
-    "        thisState,nextState=nextState,thisState\n",
-    "\n",
+    "        thisState,nextState=nextState,thisState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# __MAIN CODE__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
     "# Create the dictionary\n",
     "createpostsynaptic()\n",
     "dist=0\n",
-    "gpg.set_speed(120)\n",
+    "gpg.set_speed(240)\n",
     "print(\"Voltage: \", gpg.volt())\n",
     "tfood = 0\n",
     "try:\n",
@@ -4899,7 +5601,8 @@
     "    while True:\n",
     "        ## Start comment - use a fixed value if you want to stimulte nose touch\n",
     "        ## use something like \"dist = 27\" if you want to stop nose stimulation\n",
-    "\n",
+    "        gpg.set_eye_color(awake_color)\n",
+    "        gpg.open_eyes()\n",
     "        dist = my_distance_sensor.read()\n",
     "        if dist == 0:  # try again\n",
     "            time.sleep(0.05)\n",
@@ -4939,7 +5642,10 @@
     "                    dendriteAccumulate(\"ASJL\")\n",
     "                    runconnectome()\n",
     "                    time.sleep(0.5)\n",
-    "                    gpg.close_eyes()\n",
+    "            else:\n",
+    "                gpg.set_eye_color(awake_color)\n",
+    "                gpg.open_eyes()\n",
+    "                \n",
     "            tfood += 0.5\n",
     "            if (tfood > 20):\n",
     "                    tfood = 0\n",
@@ -4949,11 +5655,19 @@
     "except KeyboardInterrupt:\n",
     "    ## Start Comment\n",
     "    gpg.stop()\n",
+    "    gpg.close_eyes()\n",
     "    ## End Comment\n",
     "    print(\"Ctrl+C detected. Program Stopped!\")\n",
     "    for pscheck in postsynaptic:\n",
     "        print(pscheck,' ',postsynaptic[pscheck][0],' ',postsynaptic[pscheck][1])\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
It turns out that Jupyter notebooks don't like cells with 5000 lines.  In fact, less than 100 is better.

So I split all cells, and I optimized setting a dictionary to 0 on start.  It's still long to start but at least it won't crash the jupyter server. 

Did this for a specific client btw.

