### PR TITLE
Remove dependency on wiringPi

### DIFF
--- a/Install/gpg3_power.sh
+++ b/Install/gpg3_power.sh
@@ -17,6 +17,6 @@ then
 else
     echo "$SERVICE is not running"
     # Run the gopigo3_power.py if GPG3 detected
-    sudo python $REPO_PATH/Software/gopigo3_power.py
+    sudo python3 $REPO_PATH/Software/gopigo3_power.py
     echo "$SERVICE started."
 fi

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -44,6 +44,11 @@ install_wiringpi() {
     # End check if WiringPi installed
 }
 
+install_pigpio() {
+    sudo systemctl enable pigpiod
+    sudo systemctl start pigpiod
+}
+
 enable_spi() {
     feedback "Removing blacklist from /etc/modprobe.d/raspi-blacklist.conf"
 
@@ -99,6 +104,6 @@ sudo sed -i "6i $SERVICECOMMAND $SCRIPTFILE" $SERVICEFILE
 
 check_root_user
 install_dependencies
-install_wiringpi
+install_pigpio
 enable_spi
 install_wifi_antenna

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -45,6 +45,7 @@ install_wiringpi() {
 }
 
 install_pigpio() {
+    feedback "Installing pigpio"
     sudo systemctl enable pigpiod
     sudo systemctl start pigpiod
 }

--- a/Install/update_gopigo3.sh
+++ b/Install/update_gopigo3.sh
@@ -143,8 +143,8 @@ parse_cmdline_arguments() {
 # called in <<install_rfrtools_repo>>
 check_dependencies() {
   command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Error occurred with RFR_Tools installation." >&2; exit 1; }
-  command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 2; }
-  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 3; }
+  command -v python2 >/dev/null 2>&1 || { echo "Executable \"python2\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 2; }
+  command -v pip2 >/dev/null 2>&1 || { echo "Executable \"pip2\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 3; }
   if [[ $usepython3exec = "true" ]]; then
     command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 4; }
     command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 5; }
@@ -199,11 +199,11 @@ clone_gopigo3() {
 
 # called by <<install_python_pkgs_and_dependencies>>
 install_python_packages() {
-  [[ $systemwide = "true" ]] && sudo python setup.py install \
+  [[ $systemwide = "true" ]] && sudo python2 setup.py install \
               && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install
-  [[ $userlocal = "true" ]] && python setup.py install --user \
+  [[ $userlocal = "true" ]] && python2 setup.py install --user \
               && [[ $usepython3exec = "true" ]] && python3 setup.py install --user
-  [[ $envlocal = "true" ]] && python setup.py install \
+  [[ $envlocal = "true" ]] && python2 setup.py install \
               && [[ $usepython3exec = "true" ]] && python3 setup.py install
 }
 
@@ -217,10 +217,10 @@ remove_python_packages() {
   # saves output to file because we want to have the syntax highlight working
   # does this for both root and the current user because packages can be either system-wide or local
   # later on the strings used with the python command can be put in just one string that gets used repeatedly
-  python -c "import pkgutil; import os; \
+  python2 -c "import pkgutil; import os; \
               eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
               output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
-  sudo python -c "import pkgutil; import os; \
+  sudo python2 -c "import pkgutil; import os; \
               eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
               output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
   if [[ $usepython3exec = "true" ]]; then

--- a/Software/Python/Examples/Control_Panel/gopigo3_control_panel.desktop
+++ b/Software/Python/Examples/Control_Panel/gopigo3_control_panel.desktop
@@ -5,5 +5,5 @@ Name=GoPiGo3 Control Panel
 Comment=GoPiGo3 Control Panel
 #Icon=/usr/share/icons/gnome/scalable/devices/input-gaming-symbolic.svg
 Icon=/home/pi/Dexter/GoPiGo3/Software/Python/Examples/Control_Panel/GoPiGo3.png
-Exec=python /home/pi/Dexter/GoPiGo3/Software/Python/Examples/Control_Panel/control_panel_gui_3.py
+Exec=python2 /home/pi/Dexter/GoPiGo3/Software/Python/Examples/Control_Panel/control_panel_gui_3.py
 NoDisplay=true

--- a/Software/Python/gopigo3.py
+++ b/Software/Python/gopigo3.py
@@ -212,9 +212,16 @@ class GoPiGo3(object):
         """
         
         # Make sure the SPI lines are configured for mode ALT0 so that the hardware SPI controller can use them
-        subprocess.call('gpio mode 12 ALT0', shell=True)
-        subprocess.call('gpio mode 13 ALT0', shell=True)
-        subprocess.call('gpio mode 14 ALT0', shell=True)
+        # subprocess.call('gpio mode 12 ALT0', shell=True)
+        # subprocess.call('gpio mode 13 ALT0', shell=True)
+        # subprocess.call('gpio mode 14 ALT0', shell=True)
+
+
+        import pigpio
+        p = pigpio.pi()
+        p.set_mode(9, pigpio.ALT0)
+        p.set_mode(10, pigpio.ALT0)
+        p.set_mode(11, pigpio.ALT0)
         
         self.SPI_Address = addr
         if detect == True:

--- a/Software/Scratch/start_local_scratch.sh
+++ b/Software/Scratch/start_local_scratch.sh
@@ -1,7 +1,7 @@
 
 echo "ensuring only one instance of GoPiGo3 Scratch Communicator"
 sudo pkill -f GoPiGo3Scratch.py
-sudo python /home/pi/Dexter/GoPiGo3/Software/Scratch/GoPiGo3Scratch.py &
+sudo python2 /home/pi/Dexter/GoPiGo3/Software/Scratch/GoPiGo3Scratch.py &
 
 echo "starting Scratch"
 scratch /home/pi/Dexter/lib/Dexter/Scratch_GUI/new.sb


### PR DESCRIPTION
Use piGPIO instead.
start the daemon in the install script, and call pigpio when instantiating a gopigo3 to ensure pins are correct for SPI communications.

Also call Python2 and python3 explicitely to avoid mistakes.  