### PR TITLE
GoPiGo3 Control_Panel WBW edit box space for 2 digit precision

### DIFF
--- a/Software/Python/Examples/Control_Panel/control_panel_gui_3.py
+++ b/Software/Python/Examples/Control_Panel/control_panel_gui_3.py
@@ -206,7 +206,8 @@ class MainPanel(wx.Panel):
 
         calibrationTurnInternalSizer = wx.BoxSizer(wx.HORIZONTAL)
         wheel_base_label = wx.StaticText(self, -1, label="Distance Between Wheels:")
-        self.wheel_base_input = wx.TextCtrl(self, value=str(wheel_base_width), size=(60, 40))
+        # allow space for XXX.XX precision on wheel_base_width
+        self.wheel_base_input = wx.TextCtrl(self, value=str(wheel_base_width), size=(70, 40))
 
         calibrationTurnInternalSizer.Add(wheel_base_label, 0, wx.ALIGN_CENTER)
         calibrationTurnInternalSizer.Add( self.wheel_base_input, 0, wx.ALIGN_CENTER|wx.EXPAND )


### PR DESCRIPTION
The Wheel Base Width edit box cuts off the last digit of a WBW with two digit precision.  

This suggested change expands the edit box slightly to fully display WBW with two digits after the decimal.  

See Issue https://github.com/DexterInd/GoPiGo3/issues/286  for screen copy for before and after.