### PR TITLE
Obstacle detection

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -230,7 +230,7 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         | For moving the `GoPiGo3`_ robot backward, the ``dist`` parameter has to be *negative*.
 
         :param float dist: The distance in ``cm`` the `GoPiGo3`_ has to move.
-        :param float dist_to_obstacle: if the distance sensor has been instantiated using the :py:meth:`~init_distance_sensor()` method then this parameter will check for an obstacle in the robot's path and stop the robot as needed, even if the target distance isn't reached.
+        :param float dist_to_obstacle: If the distance sensor has been instantiated using the :py:meth:`~init_distance_sensor()` method then this parameter will check for an obstacle in the robot's path and stop the robot as needed, even if the target distance isn't reached.
         :param boolean blocking = True: Set it as a blocking or non-blocking method.
 
         ``blocking`` parameter can take the following values:
@@ -242,8 +242,6 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         # dist is in cm
         # if dist is negative, this becomes a backward move
         print(dist, dist_to_obstacle)
-
-        dist_mm = dist * 10
 
         # the number of degrees each wheel needs to turn
         WheelTurnDegrees = ((dist_mm / self.WHEEL_CIRCUMFERENCE) * 360)

--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -241,7 +241,8 @@ class EasyGoPiGo3(gopigo3.GoPiGo3):
         """
         # dist is in cm
         # if dist is negative, this becomes a backward move
-        print(dist, dist_to_obstacle)
+
+        dist_mm = dist * 10
 
         # the number of degrees each wheel needs to turn
         WheelTurnDegrees = ((dist_mm / self.WHEEL_CIRCUMFERENCE) * 360)


### PR DESCRIPTION
A few changes with this.

1. the class will now keep track of the three DI sensors, if they are instantiated through their corresponding init_<sensor> method. This means it will now be possible to use gpg.distance_sensor for example.
CAVEAT: this does not support multiple distance_sensors on the robot, just one. Any extra distance sensors would need to be tracked outside of the easygopigo3 instance.
2. the drive_inches and drive_cm method now support an extra parameter: dist_to_obstacle. If this value is non-zero, and the distance sensor was instantiated using the init_distance_sensor method, the the drive_cm/drive_inches may get interrupted if an obstacle is detected before reaching the target.
3. the __init__ method has an extra parameter *run_init* which will determine whether we set some robot parameters or not. This is required if/when the robot is controlled via multiple processes. 