### PR TITLE
Allow for missing gpg3_config.json

### DIFF
--- a/Software/Python/gopigo3.py
+++ b/Software/Python/gopigo3.py
@@ -250,10 +250,9 @@ class GoPiGo3(object):
         # also default ENCODER_TICKS_PER_ROTATION and MOTOR_GEAR_RATIO
         # should there be a problem doing that then save the current default configuration
         try:
-            self.load_robot_constants()
+            self.load_robot_constants(config_file_path)
         except Exception as e:
-            print("Exception happened while loaded robot constants:")
-            print(e)
+            # This may happen if the file doesn't exist
             pass
 
     def spi_transfer_array(self, data_out):

--- a/Software/Python/gopigo3.py
+++ b/Software/Python/gopigo3.py
@@ -231,7 +231,6 @@ class GoPiGo3(object):
         p.set_mode(10, pigpio.ALT0)
         p.set_mode(11, pigpio.ALT0)
 
-        print("new init")
         self.SPI_Address = addr
         if detect == True:
             try:
@@ -252,7 +251,6 @@ class GoPiGo3(object):
         # should there be a problem doing that then save the current default configuration
         try:
             self.load_robot_constants()
-            print("Robot constants loaded")
         except Exception as e:
             print("Exception happened while loaded robot constants:")
             print(e)


### PR DESCRIPTION
remove some print statements, and ignore the fact the gpg3_config.json may be missing. It's perfectly fine if it's missing, we just use the defaults.