### PR TITLE
PiGPIO no longer leaking resources

### DIFF
--- a/Software/Python/easygopigo3.py
+++ b/Software/Python/easygopigo3.py
@@ -13,7 +13,7 @@ import json
 import easysensors
 from I2C_mutex import Mutex
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 try:
     from di_sensors import easy_line_follower, easy_distance_sensor, easy_light_color_sensor, easy_inertial_measurement_unit

--- a/Software/Python/setup.py
+++ b/Software/Python/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "gopigo3",
-    version = "1.3.0",
+    version = "1.3.2",
 
     description = "Drivers and Examples for using the GoPiGo3 in Python",
     long_description = description,


### PR DESCRIPTION
A call to pigpio.stop() is required, otherwise in multithreaded environments, or if a gopigo program is run multiple times one after the other, we end up with a pigpio complaint and the robot stops running.

Here's the pigpio error message that is taken care of with this PR:
```
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
Can't connect to pigpio at localhost(8888)

Can't create callback thread.
Perhaps too many simultaneous pigpio connections.
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
```