### PR TITLE
Add 16 tick support to C++ GoPiGo3 API, with drive GoPiGo3 example

### DIFF
--- a/Software/C/CMakeLists.txt
+++ b/Software/C/CMakeLists.txt
@@ -34,6 +34,10 @@ target_link_libraries(motors gopigo3)
 add_executable(sensors Examples/sensors.cpp)
 target_link_libraries(sensors gopigo3)
 
+# drive
+add_executable(drive Examples/drive.cpp)
+target_link_libraries(drive gopigo3)
+
 ### Installation
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/

--- a/Software/C/Examples/drive.cpp
+++ b/Software/C/Examples/drive.cpp
@@ -1,0 +1,130 @@
+/*   FILE:  drive.cpp
+
+     PURPOSE:  Demonstrate using GoPiGo3 motors and encoders in C++
+
+     BUILDING:
+        Use cmake:
+           - cd /home/pi/Dexter/GoPiGo3/Software/C
+           - cmake CMakeLists.txt
+           - make
+
+     USAGE:
+         - /home/pi/Dexter/GoPiGo3/Software/C/drive
+           or
+         - cd /home/pi/Dexter/GoPiGo3/Software/C
+           ./drive
+
+         - press q to quit program (only way, ctrl-c does not exit)
+         - press spacebar to stop GoPiGo3
+         - press s to spin GoPiGo3
+         - press a to rotate around left wheel
+         - press d to rotate around right wheel
+         - press w to drive forward
+         - press x to drive backward
+         - press r to reset encoders to 0
+*/
+
+#include <GoPiGo3.h>   // for GoPiGo3
+#include <stdio.h>     // for printf
+#include <unistd.h>    // for usleep
+#include <signal.h>    // for catching exit signals
+
+
+#define NO_LIMIT_SPEED 1000
+
+GoPiGo3 GPG;
+
+void exit_signal_handler(int signo);
+
+int main(){
+
+        int left_enc, right_enc;
+
+	signal(SIGINT, exit_signal_handler); // register the exit function for Ctrl+C
+
+	GPG.detect();
+
+	printf("\n**** GoPiGo3 Robot Constants:\n");
+	printf(" - WHEEL_DIAMETER: %.3f mm\n", GPG.WHEEL_DIAMETER);
+	printf(" - WHEEL_BASE_WIDTH: %.3f mm\n", GPG.WHEEL_BASE_WIDTH);
+	printf(" - ENCODER_TICKS_PER_ROTATION: %d\n", GPG.ENCODER_TICKS_PER_ROTATION);
+	printf(" - MOTOR_GEAR_RATIO: %d\n", GPG.MOTOR_GEAR_RATIO);
+
+
+
+	bool keepLooping = true;
+        printf("\n****");
+	printf("\n        fwd w                  r reset encoders ");
+	printf("\n left  a  spin s   d  right");
+	printf("\n            bkwd x ");
+        printf("\n                               spacebar  STOP");
+        printf("\n****");
+
+	GPG.reset_motor_encoder(MOTOR_LEFT + MOTOR_RIGHT);
+
+	// GPG.set_motor_limits(MOTOR_LEFT,0,300);
+	// GPG.set_motor_limits(MOTOR_RIGHT,0,300);
+	GPG.set_motor_limits(MOTOR_LEFT,0,0);
+	GPG.set_motor_limits(MOTOR_RIGHT,0,0);
+
+	do{
+
+                printf("\n");
+                GPG.get_motor_encoder(MOTOR_LEFT,left_enc);
+                GPG.get_motor_encoder(MOTOR_RIGHT,right_enc);
+
+		printf("\nencoders: (%d, %d) Cmd: (q to exit): ",left_enc,right_enc);
+
+		// using stty raw is a terrible idea, not recommended!
+		system("stty raw");
+		char c = getchar();
+                system("stty cooked");
+
+		switch(c){
+			case 'w':  // forward
+				GPG.set_motor_dps(MOTOR_LEFT + MOTOR_RIGHT, NO_LIMIT_SPEED);
+				break;
+			case 'x' :    // backward
+				GPG.set_motor_dps(MOTOR_LEFT + MOTOR_RIGHT, NO_LIMIT_SPEED * -1);
+				break;
+			case 'd' :    // right turn
+				GPG.set_motor_dps(MOTOR_LEFT, NO_LIMIT_SPEED);
+				GPG.set_motor_dps(MOTOR_RIGHT, 0);
+				break;
+			case 'a' :     // left turn
+				GPG.set_motor_dps(MOTOR_LEFT, 0);
+				GPG.set_motor_dps(MOTOR_RIGHT, NO_LIMIT_SPEED);
+				break;
+			case 'q' :     // quit
+				GPG.set_motor_dps(MOTOR_LEFT + MOTOR_RIGHT, 0);
+				keepLooping = false;
+				break;
+			case ' ' :  // stop
+				GPG.set_motor_dps(MOTOR_LEFT + MOTOR_RIGHT, 0);
+				std::cout << "stopping..";
+				std::cout.flush();
+				sleep(1); // wait for stop to finish
+				break;
+			case 's' :  // spin
+				GPG.set_motor_dps(MOTOR_LEFT, (int)(NO_LIMIT_SPEED/2) );
+				GPG.set_motor_dps(MOTOR_RIGHT, (int)(-NO_LIMIT_SPEED/2) );
+				break;
+			case 'r' :  // reset encoders to zero
+				GPG.reset_motor_encoder(MOTOR_LEFT + MOTOR_RIGHT);
+				break;
+
+		}
+	} while (keepLooping);
+	system("stty cooked");
+        printf("\n");
+}
+
+
+void exit_signal_handler(int signo){
+	  if(signo == SIGINT){
+         GPG.reset_all();    // Reset everything so there are no run-away motors
+         system("stty cooked");
+         printf("\n");
+         exit(-2);
+	  }
+}

--- a/Software/C/GoPiGo3.h
+++ b/Software/C/GoPiGo3.h
@@ -31,6 +31,13 @@
 #include <sys/time.h>         // for clock_gettime
 #include <unistd.h>
 #include <stdexcept>
+#include <cmath>             // for pi
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
 
 // Error values
 #define ERROR_NONE                  0
@@ -239,6 +246,15 @@ class GoPiGo3{
   // Set up the GoPiGo3
     GoPiGo3();
 
+    // Instance Variables
+    float WHEEL_BASE_WIDTH         = 117;     // default distance (mm) from left wheel to right wheel.
+    float WHEEL_DIAMETER           = 66.5;    // defautl wheel diameter (mm)
+    float WHEEL_BASE_CIRCUMFERENCE = WHEEL_BASE_WIDTH * M_PI;  // pi from cmath
+    float WHEEL_CIRCUMFERENCE      = WHEEL_DIAMETER   * M_PI;  // pi from cmath
+    int   MOTOR_GEAR_RATIO         = 120;
+    int   ENCODER_TICKS_PER_ROTATION = 6;  // default GoPiGo3 has 6 ticks, 16 ticks if in .list_of_serial_numbers.pkl file
+    int   MOTOR_TICKS_PER_DEGREE     = ((MOTOR_GEAR_RATIO * ENCODER_TICKS_PER_ROTATION) / 360.0);  // ticks per degree of wheel shaft rotation
+
   // Confirm that the BrickPi3 is connected and up-to-date
     int     detect(bool critical = true);
 
@@ -252,6 +268,16 @@ class GoPiGo3{
     int     get_version_firmware(char *str);
   // Get the serial number ID that is unique to each BrickPi3
     int     get_id(char *str);
+
+
+  // Check if serial number in file of 16 tick GoPiGo3
+    bool    check_serial_number_for_16_ticks(std::string serial_file_path="/home/pi/Dexter/.list_of_serial_numbers.pkl");
+  // Load wheel diameter, wheel base, ticks per revolution, motor gear ratio from file if exists
+    int     load_robot_constants(std::string config_file_path="/home/pi/Dexter/gpg3_config.json");
+  // Save wheel diameter, wheel base, ticks per revolution, motor gear ratio to JSON file
+    int     save_robot_constants(std::string config_file_path="/home/pi/Dexter/gpg3_config.json");
+  // Set new robot constant values and dependent constants
+    int     set_robot_constants(float wheel_diameter, float wheel_base_width, int ticks, int motor_gear_ratio);
 
   // Control the LED
     int     set_led(uint8_t led, uint8_t red, uint8_t green = 0, uint8_t blue = 0);
@@ -284,7 +310,8 @@ class GoPiGo3{
     int     get_motor_encoder(uint8_t port, int32_t &value);
     // Pass the port. Returns the encoder value.
     int32_t get_motor_encoder(uint8_t port);
-
+    // Set ecoder value to 0
+    int     reset_motor_encoder(uint8_t port);
 
   // Configure grove pin(s)/port(s)
     // Set grove port type

--- a/Software/C/package.xml
+++ b/Software/C/package.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gopigo3_cpp</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>C++ driver for GoPiGo3</description>
 
-  <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
+  <maintainer email="support@modrobotics.com">Modular Robotics</maintainer>
 
   <license>MIT</license>
 
-  <url type="website">https://www.dexterindustries.com/gopigo3/</url>
+  <url type="website">https://GoPiGo.io</url>
   <url type="website">https://github.com/DexterInd/GoPiGo3</url>
 
 


### PR DESCRIPTION
=== Changes to C++ GoPiGo3 API

GoPiGo3.h
- Added Instance Variables:
  - WHEEL_BASE_WIDTH, WHEEL_BASE_DIAMETER, ENCODER_TICKS_PER_ROTATION, MOTOR_GEAR_RATIO
  - computed Instance Variables: WHEEL_BASE_CIRCUMFERENCE, WHEEL_CIRCUMFERENCE, MOTOR_TICKS_PER_DEGREE
- Added Declarations:
  - check_serial_number_for_16_ticks()
  - load_robot_constants()
  - save_robot_constants()
  - set_robot_constants()
  - reset_motor_encoder()

GoPiGo3.cpp
- Added to GoPiGo3 object initialization:
  - load_robot_constants()

- Added Definitions:
  - check_serial_number_for_16_ticks()
  - load_robot_constants()
  - save_robot_constants()
  - set_robot_constants()
  - reset_motor_encoder()

Examples/
- Added drive.cpp: Drive GoPiGo3 using keyboard keys, showing encoder values

CMakeLists.txt
- Added Examples/drive.cpp

package.xml
- upped version to 0.0.1
- changed maintainer to support@modrobotics.com
- changed website to GoPiGo.io